### PR TITLE
fix: only mutate with pks only, if the key either does not fitler on …

### DIFF
--- a/.changeset/old-countries-bow.md
+++ b/.changeset/old-countries-bow.md
@@ -1,0 +1,6 @@
+---
+"@supabase-cache-helpers/postgrest-filter": patch
+"@supabase-cache-helpers/postgrest-mutate": patch
+---
+
+only mutate with pks only, if the key either does not fitler on pks, or the input matches all pk filters

--- a/packages/postgrest-filter/__tests__/lib/transform-recursive.spec.ts
+++ b/packages/postgrest-filter/__tests__/lib/transform-recursive.spec.ts
@@ -1,6 +1,29 @@
 import { transformRecursive } from '../../src';
 
 describe('transformRecursive', () => {
+  it('should transform nulls to null', () => {
+    expect(
+      transformRecursive(
+        [
+          {
+            alias: 'id',
+            declaration: 'id',
+            path: 'id',
+          },
+          {
+            alias: 'full_name',
+            declaration: 'full_name:display_name',
+            path: 'display_name',
+          },
+        ],
+        {
+          id: null,
+          display_name: null,
+        },
+        'path'
+      )
+    ).toEqual({ id: null, display_name: null });
+  });
   it('should transform nulls of relation to null', () => {
     expect(
       transformRecursive(

--- a/packages/postgrest-filter/__tests__/postgrest-filter.spec.ts
+++ b/packages/postgrest-filter/__tests__/postgrest-filter.spec.ts
@@ -354,6 +354,129 @@ describe('PostgrestFilter', () => {
       ).toEqual(false);
     });
   });
+
+  describe('.hasFiltersOnPaths', () => {
+    it('should return false if there is no filter on the given paths', () => {
+      expect(
+        new PostgrestFilter({
+          filters: [
+            {
+              or: [
+                {
+                  path: 'some_other_path',
+                  alias: 'text',
+                  negate: false,
+                  operator: 'eq',
+                  value: 'some-text',
+                },
+              ],
+            },
+          ],
+          paths: [
+            { path: 'text', declaration: 'text' },
+            { path: 'array', declaration: 'array' },
+            { path: 'some.nested.value', declaration: 'some.nested.value' },
+          ],
+        }).hasFiltersOnPaths(['some_path', 'some_unexisting_path'])
+      ).toEqual(false);
+    });
+    it('should return true if any path is included', () => {
+      expect(
+        new PostgrestFilter({
+          filters: [
+            {
+              or: [
+                {
+                  path: 'id',
+                  alias: undefined,
+                  negate: false,
+                  operator: 'eq',
+                  value: 1,
+                },
+                {
+                  path: 'some_other_path',
+                  alias: 'text',
+                  negate: false,
+                  operator: 'eq',
+                  value: 'some-text',
+                },
+              ],
+            },
+          ],
+          paths: [
+            { path: 'text', declaration: 'text' },
+            { path: 'array', declaration: 'array' },
+            { path: 'some.nested.value', declaration: 'some.nested.value' },
+          ],
+        }).hasFiltersOnPaths(['some_unexisting_path', 'id'])
+      ).toEqual(true);
+    });
+  });
+
+  describe('.applyFiltersOnPaths', () => {
+    it('with and', () => {
+      expect(
+        new PostgrestFilter({
+          filters: [
+            {
+              and: [
+                {
+                  path: 'some_other_path',
+                  alias: 'text',
+                  negate: false,
+                  operator: 'eq',
+                  value: 'some-text',
+                },
+                {
+                  path: 'id',
+                  negate: false,
+                  operator: 'eq',
+                  value: 5,
+                },
+              ],
+            },
+          ],
+          paths: [
+            { path: 'text', declaration: 'text' },
+            { path: 'array', declaration: 'array' },
+            { path: 'some.nested.value', declaration: 'some.nested.value' },
+          ],
+        }).applyFiltersOnPaths(MOCK, ['some_other_path'])
+      ).toEqual(true);
+    });
+    it('with or', () => {
+      expect(
+        new PostgrestFilter({
+          filters: [
+            {
+              or: [
+                {
+                  path: 'some_other_path',
+                  alias: 'text',
+                  negate: false,
+                  operator: 'eq',
+                  value: 'some-text-123',
+                },
+
+                {
+                  path: 'id',
+                  negate: false,
+                  operator: 'eq',
+                  value: 1,
+                },
+              ],
+            },
+          ],
+          paths: [
+            { path: 'text', declaration: 'text' },
+            { path: 'array', declaration: 'array' },
+            { path: 'some.nested.value', declaration: 'some.nested.value' },
+          ],
+        }).applyFiltersOnPaths(MOCK, ['some_other_path'])
+      ).toEqual(false);
+    });
+  });
+
   describe('.apply', () => {
     it('with alias', () => {
       expect(
@@ -367,6 +490,12 @@ describe('PostgrestFilter', () => {
                   negate: false,
                   operator: 'eq',
                   value: 'some-text',
+                },
+                {
+                  path: 'id',
+                  negate: false,
+                  operator: 'eq',
+                  value: 5,
                 },
               ],
             },

--- a/packages/postgrest-filter/src/lib/filter-filter-definitions-by-paths.ts
+++ b/packages/postgrest-filter/src/lib/filter-filter-definitions-by-paths.ts
@@ -1,0 +1,28 @@
+import {
+  isAndFilter,
+  isOrFilter,
+  isFilterDefinition,
+  FilterDefinitions,
+} from './types';
+
+export const filterFilterDefinitionsByPaths = (
+  f: FilterDefinitions,
+  paths: string[]
+) => {
+  return f.reduce<FilterDefinitions>((prev, filter) => {
+    if (isAndFilter(filter)) {
+      const filters = filterFilterDefinitionsByPaths(filter.and, paths);
+      if (filters.length > 0) {
+        prev.push({ and: filters });
+      }
+    } else if (isOrFilter(filter)) {
+      const filters = filterFilterDefinitionsByPaths(filter.or, paths);
+      if (filters.length > 0) {
+        prev.push({ or: filters });
+      }
+    } else if (isFilterDefinition(filter) && paths.includes(filter.path)) {
+      prev.push(filter);
+    }
+    return prev;
+  }, []);
+};

--- a/packages/postgrest-filter/src/lib/index.ts
+++ b/packages/postgrest-filter/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './extract-paths-from-filters';
+export * from './filter-filter-definitions-by-paths';
 export * from './group-paths-recursive';
 export * from './normalize';
 export * from './operators';

--- a/packages/postgrest-filter/src/postgrest-filter.ts
+++ b/packages/postgrest-filter/src/postgrest-filter.ts
@@ -13,6 +13,7 @@ import {
   ValueType,
   extractPathsFromFilters,
   transformRecursive,
+  filterFilterDefinitionsByPaths,
 } from './lib';
 import {
   PostgrestQueryParser,
@@ -78,6 +79,22 @@ export class PostgrestFilter<Result extends Record<string, unknown>> {
         filterFns.every((fn) => isObject(obj) && fn(obj));
     }
     return this._filtersFn(obj);
+  }
+
+  hasFiltersOnPaths(paths: string[]): boolean {
+    return (
+      filterFilterDefinitionsByPaths(this.params.filters, paths).length > 0
+    );
+  }
+
+  applyFiltersOnPaths(obj: unknown, paths: string[]): obj is Result {
+    const filterFns = filterFilterDefinitionsByPaths(
+      this.params.filters,
+      paths
+    ).map((d) => this.buildFilterFn(d));
+    const filtersFn = (obj: unknown): obj is Result =>
+      filterFns.every((fn) => isObject(obj) && fn(obj));
+    return filtersFn(obj);
   }
 
   hasPaths(obj: unknown): obj is Result {

--- a/packages/postgrest-mutate/__tests__/delete.spec.ts
+++ b/packages/postgrest-mutate/__tests__/delete.spec.ts
@@ -27,6 +27,10 @@ describe('deleteItem', () => {
         },
         getPostgrestFilter() {
           return {
+            applyFiltersOnPaths: (obj: unknown): obj is ItemType => true,
+            hasFiltersOnPaths() {
+              return true;
+            },
             transform: (obj) => obj,
             apply(obj): obj is ItemType {
               return true;

--- a/packages/postgrest-mutate/__tests__/upsert.spec.ts
+++ b/packages/postgrest-mutate/__tests__/upsert.spec.ts
@@ -27,6 +27,10 @@ describe('upsertItem', () => {
         },
         getPostgrestFilter() {
           return {
+            applyFiltersOnPaths: (obj: unknown): obj is ItemType => true,
+            hasFiltersOnPaths() {
+              return true;
+            },
             transform: (obj) => obj,
             apply(obj: unknown): obj is ItemType {
               return true;

--- a/packages/postgrest-mutate/package.json
+++ b/packages/postgrest-mutate/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsup",
     "test": "jest --coverage",
+    "jest": "jest",
     "clean": "rm -rf .turbo && rm -rf lint-results && rm -rf .nyc_output && rm -rf node_modules && rm -rf dist",
     "lint": "eslint src/**",
     "lint:report": "eslint src/** --format json --output-file ./lint-results/postgrest-mutate.json",


### PR DESCRIPTION
…pks, or the input matches all pk filters