### PR TITLE
Fix types for mjs

### DIFF
--- a/.changeset/olive-squids-flow.md
+++ b/.changeset/olive-squids-flow.md
@@ -1,0 +1,14 @@
+---
+"@supabase-cache-helpers/postgrest-react-query": patch
+"@supabase-cache-helpers/storage-react-query": patch
+"@supabase-cache-helpers/postgrest-fetcher": patch
+"@supabase-cache-helpers/postgrest-filter": patch
+"@supabase-cache-helpers/postgrest-mutate": patch
+"@supabase-cache-helpers/postgrest-shared": patch
+"@supabase-cache-helpers/storage-fetcher": patch
+"@supabase-cache-helpers/storage-mutate": patch
+"@supabase-cache-helpers/postgrest-swr": patch
+"@supabase-cache-helpers/storage-swr": patch
+---
+
+Fix types for mjs when using "moduleResolution" other then "node" (node16, nodenext, bundler)

--- a/packages/postgrest-fetcher/package.json
+++ b/packages/postgrest-fetcher/package.json
@@ -6,6 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/postgrest-filter/package.json
+++ b/packages/postgrest-filter/package.json
@@ -4,6 +4,7 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/postgrest-mutate/package.json
+++ b/packages/postgrest-mutate/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/postgrest-react-query/package.json
+++ b/packages/postgrest-react-query/package.json
@@ -17,6 +17,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/postgrest-shared/package.json
+++ b/packages/postgrest-shared/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/postgrest-swr/package.json
+++ b/packages/postgrest-swr/package.json
@@ -10,6 +10,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/storage-fetcher/package.json
+++ b/packages/storage-fetcher/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/storage-mutate/package.json
+++ b/packages/storage-mutate/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/storage-react-query/package.json
+++ b/packages/storage-react-query/package.json
@@ -10,6 +10,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },

--- a/packages/storage-swr/package.json
+++ b/packages/storage-swr/package.json
@@ -10,6 +10,7 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
When using `moduleResolution` other then old `node` (node16, nodenext, bundler) there is a TS error:
```
Could not find a declaration file for module '@supabase-cache-helpers/postgrest-react-query'.
There are types at 'node_modules/@supabase-cache-helpers/postgrest-react-query/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@supabase-cache-helpers/postgrest-react-query' library may need to update its package.json or typings.
```
Here is more context https://github.com/egoist/tsup/issues/760#issuecomment-1451112010