### PR TITLE
Fix missing exports in postgrest-react-query

### DIFF
--- a/.changeset/early-seals-rush.md
+++ b/.changeset/early-seals-rush.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-react-query": patch
+---
+
+Fix missing exports in postgrest-react-query

--- a/packages/postgrest-react-query/src/index.ts
+++ b/packages/postgrest-react-query/src/index.ts
@@ -1,3 +1,9 @@
+export * from '@supabase-cache-helpers/postgrest-shared';
+export * from '@supabase-cache-helpers/postgrest-filter';
+export * from '@supabase-cache-helpers/postgrest-fetcher';
+
+export * from './cache';
+export * from './lib';
 export * from './mutate';
 export * from './query';
 export * from './subscribe';


### PR DESCRIPTION
The postgrest-react-query package is currently missing some exports mentioned in the docs (e.g. useUpsertItem, useDeleteItem). I've adjusted them so that they are identical to postgrest-swr's ones.