### PR TITLE
Export types and interfaces

### DIFF
--- a/.changeset/clean-rings-laugh.md
+++ b/.changeset/clean-rings-laugh.md
@@ -1,0 +1,6 @@
+---
+"@supabase-cache-helpers/postgrest-react-query": minor
+"@supabase-cache-helpers/postgrest-swr": minor
+---
+
+Export types, such as GetFetcherOptions, UseQuerySingleReturn, UseQueryMaybeSingleReturn and others

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
   "engines": {
     "pnpm": "8",
     "node": ">=14.0.0"
-  }
+  },
+  "packageManager": "pnpm@8"
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,5 @@
   "engines": {
     "pnpm": "8",
     "node": ">=14.0.0"
-  },
-  "packageManager": "pnpm@8"
+  }
 }

--- a/packages/postgrest-react-query/src/mutate/types.ts
+++ b/packages/postgrest-react-query/src/mutate/types.ts
@@ -15,7 +15,7 @@ import { UseMutationOptions } from '@tanstack/react-query';
 
 export type Operation = 'Insert' | 'UpdateOne' | 'Upsert' | 'DeleteOne';
 
-type GetFetcherOptions<
+export type GetFetcherOptions<
   S extends GenericSchema,
   T extends GenericTable,
   O extends Operation,

--- a/packages/postgrest-react-query/src/query/use-query.ts
+++ b/packages/postgrest-react-query/src/query/use-query.ts
@@ -20,7 +20,7 @@ import { encode } from '../lib/key';
  * Represents the return value of the `useQuery` hook when `query` is expected to return
  * a single row.
  */
-type UseQuerySingleReturn<Result> = Omit<
+export type UseQuerySingleReturn<Result> = Omit<
   UseReactQueryResult<PostgrestSingleResponse<Result>['data'], PostgrestError>,
   'refetch'
 > &
@@ -34,7 +34,7 @@ type UseQuerySingleReturn<Result> = Omit<
  * Represents the return value of the `useQuery` hook when `query` is expected to return
  * either a single row or an empty response.
  */
-type UseQueryMaybeSingleReturn<Result> = Omit<
+export type UseQueryMaybeSingleReturn<Result> = Omit<
   UseReactQueryResult<
     PostgrestMaybeSingleResponse<Result>['data'],
     PostgrestError
@@ -51,7 +51,7 @@ type UseQueryMaybeSingleReturn<Result> = Omit<
  * Represents the return value of the `useQuery` hook when `query` is expected to return
  * one or more rows.
  */
-type UseQueryReturn<Result> = Omit<
+export type UseQueryReturn<Result> = Omit<
   UseReactQueryResult<PostgrestResponse<Result>['data'], PostgrestError>,
   'refetch'
 > &

--- a/packages/postgrest-swr/src/mutate/types.ts
+++ b/packages/postgrest-swr/src/mutate/types.ts
@@ -18,7 +18,7 @@ export type { SWRMutationConfiguration, PostgrestError };
 
 export type Operation = 'Insert' | 'UpdateOne' | 'Upsert' | 'DeleteOne';
 
-type GetFetcherOptions<
+export type GetFetcherOptions<
   S extends GenericSchema,
   T extends GenericTable,
   O extends Operation,

--- a/packages/postgrest-swr/src/query/use-query.ts
+++ b/packages/postgrest-swr/src/query/use-query.ts
@@ -16,7 +16,7 @@ import { encode } from '../lib';
 /**
  * The return type of `useQuery` for `.single()` record results
  */
-type UseQuerySingleReturn<Result> = Omit<
+export type UseQuerySingleReturn<Result> = Omit<
   SWRResponse<PostgrestSingleResponse<Result>['data'], PostgrestError>,
   'mutate'
 > &
@@ -26,7 +26,7 @@ type UseQuerySingleReturn<Result> = Omit<
 /**
  * The return type of `useQuery` for `.maybeSingle()` queries
  */
-type UseQueryMaybeSingleReturn<Result> = Omit<
+export type UseQueryMaybeSingleReturn<Result> = Omit<
   SWRResponse<PostgrestMaybeSingleResponse<Result>['data'], PostgrestError>,
   'mutate'
 > &
@@ -39,7 +39,7 @@ type UseQueryMaybeSingleReturn<Result> = Omit<
 /**
  * The default return type of `useQuery` queries
  */
-type UseQueryReturn<Result> = Omit<
+export type UseQueryReturn<Result> = Omit<
   SWRResponse<PostgrestResponse<Result>['data'], PostgrestError>,
   'mutate'
 > &


### PR DESCRIPTION
This PR exports the packages types so that developers can use it in their projects

Related issue: https://github.com/psteinroe/supabase-cache-helpers/issues/350 