### PR TITLE
Add react-server export support for postgrest-swr package and edit docs

### DIFF
--- a/.changeset/big-gorillas-train.md
+++ b/.changeset/big-gorillas-train.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-swr": minor
+---
+
+add react-server export for react server component compatibility

--- a/docs/pages/postgrest/ssr/swr.mdx
+++ b/docs/pages/postgrest/ssr/swr.mdx
@@ -18,22 +18,29 @@ or define it globally in `SWRConfig`
 
 Supabase Cache Helpers exports helper to simplify it for every query type.
 
+<Callout emoji="⚠️ ">
+  Using the NextJS App Router and react server components requires importing
+  `fetchQueryFallbackData`, `fetchOffsetPaginationFallbackData`,
+  `fetchOffsetPaginationHasMoreFallbackData` from
+  `@supabase-cache-helpers/postgrest-swr/react-server`. All other exports are
+  suitable for client components only.
+</Callout>
+
 ### `useQuery`
 
 Fetch fallback data for `useQuery` using `fetchQueryFallbackData`.
 
-```tsx
 const buildQuery = (supabase: SupabaseClient) => {
-   return supabase.from('article').select('id,title');
+return supabase.from('article').select('id,title');
 };
 
 export async function getStaticProps() {
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
   const [key, fallbackData] = await fetchQueryFallbackData(
-    buildQuery(supabase),
+    buildQuery(supabase)
   );
   return {
     props: {
@@ -49,7 +56,8 @@ export default function Articles({ fallback }) {
     ...
 
 }
-```
+
+````
 
 The data can also be passed globally using `key`.
 
@@ -81,7 +89,7 @@ export default function App({ fallback }) {
         </SWRConfig>
     )
 }
-```
+````
 
 ### `useOffsetInfiniteQuery`
 

--- a/docs/pages/postgrest/ssr/swr.mdx
+++ b/docs/pages/postgrest/ssr/swr.mdx
@@ -37,10 +37,10 @@ return supabase.from('article').select('id,title');
 export async function getStaticProps() {
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   );
   const [key, fallbackData] = await fetchQueryFallbackData(
-    buildQuery(supabase)
+    buildQuery(supabase),
   );
   return {
     props: {

--- a/packages/postgrest-swr/package.json
+++ b/packages/postgrest-swr/package.json
@@ -14,6 +14,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./react-server": {
+      "types": "./dist/index.react-server.d.ts",
+      "import": "./dist/index.react-server.mjs",
+      "require": "./dist/index.react-server.js"
+    },
     "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",
@@ -47,35 +52,36 @@
     "directory": "packages/postgrest-swr"
   },
   "peerDependencies": {
-    "swr": "^2.2.0",
+    "@supabase/postgrest-js": "^1.9.0",
     "react": "^16.11.0 || ^17.0.0 || ^18.0.0",
-    "@supabase/postgrest-js": "^1.9.0"
+    "swr": "^2.2.0"
   },
   "jest": {
     "preset": "@supabase-cache-helpers/jest-presets/jest/node"
   },
   "devDependencies": {
-    "@supabase/supabase-js": "2.38.5",
-    "@supabase/postgrest-js": "1.9.0",
-    "@testing-library/react": "14.1.0",
-    "@testing-library/jest-dom": "6.1.4",
-    "jest-environment-jsdom": "29.7.0",
-    "@types/jest": "29.5.0",
-    "dotenv": "16.3.1",
-    "eslint": "8.54.0",
     "@supabase-cache-helpers/eslint-config-custom": "workspace:*",
-    "jest": "29.7.0",
     "@supabase-cache-helpers/jest-presets": "workspace:*",
     "@supabase-cache-helpers/prettier-config": "workspace:*",
-    "ts-jest": "29.1.0",
     "@supabase-cache-helpers/tsconfig": "workspace:*",
-    "tsup": "8.0.0",
-    "react": "18.2.0",
+    "@supabase/postgrest-js": "1.9.0",
+    "@supabase/supabase-js": "2.38.5",
+    "@testing-library/jest-dom": "6.1.4",
+    "@testing-library/react": "14.1.0",
+    "@types/jest": "29.5.0",
     "@types/react": "18.2.0",
+    "dotenv": "16.3.1",
+    "eslint": "8.54.0",
+    "jest": "29.7.0",
+    "jest-environment-jsdom": "29.7.0",
+    "react": "18.2.0",
     "react-dom": "18.2.0",
+    "ts-jest": "29.1.0",
+    "tsup": "8.0.0",
     "typescript": "5.3.2"
   },
   "dependencies": {
-    "@supabase-cache-helpers/postgrest-core": "workspace:*"
+    "@supabase-cache-helpers/postgrest-core": "workspace:*",
+    "server-only": "^0.0.1"
   }
 }

--- a/packages/postgrest-swr/src/index.react-server.ts
+++ b/packages/postgrest-swr/src/index.react-server.ts
@@ -1,0 +1,4 @@
+// Server only flag in case other RSC compatible exports are added here later
+import 'server-only';
+
+export * from './query/prefetch';

--- a/packages/postgrest-swr/tsup.config.ts
+++ b/packages/postgrest-swr/tsup.config.ts
@@ -2,7 +2,7 @@ import type { Options } from 'tsup';
 
 export const tsup: Options = {
   dts: true,
-  entryPoints: ['src/index.ts'],
+  entryPoints: ['src/index.ts', 'src/index.react-server.ts'],
   external: ['react', /^@supabase\//],
   format: ['cjs', 'esm'],
   //   inject: ['src/react-shim.js'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,9 @@ importers:
       '@supabase-cache-helpers/postgrest-core':
         specifier: workspace:*
         version: link:../postgrest-core
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       swr:
         specifier: ^2.2.0
         version: 2.2.0(react@18.2.0)
@@ -3631,7 +3634,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.18.9
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       '@radix-ui/react-context': 1.0.0(react@18.2.0)
@@ -10523,6 +10526,10 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+
+  /server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}


### PR DESCRIPTION
- [x] Added support for React Server Component specific exports. Useful for NextJS app router and (soon) other React frameworks that implement RSC. Decided to add a specific ```...postgrest-swr/react-server``` namespace for RSC compatible exports as it is a (potentially) breaking change for some frameworks, it keeps any RSC compatibility issues and support in one place and there is a clear boundary between more strict framework exports like this and looser exports in the general package.
- [x] Added ```server-only``` to RSC namespace: Might as well enforce the strictest use in server components given this is a separate export anyway.
- [x] Added a short entry to the docs. Let me know if you think this might need tweak - I thought about adding larger NextJS section but I think that supabase-cache-helpers should continue to be framework agnostic.

References https://github.com/psteinroe/supabase-cache-helpers/issues/261#issuecomment-1850167194

