### PR TITLE
fix: make revalidate relations and table work again

### DIFF
--- a/.changeset/rude-glasses-battle.md
+++ b/.changeset/rude-glasses-battle.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-swr": patch
+---
+
+fix: pass key to mutate when revalidating in swr

--- a/packages/postgrest-swr/src/cache/use-delete-item.ts
+++ b/packages/postgrest-swr/src/cache/use-delete-item.ts
@@ -30,7 +30,9 @@ export function useDeleteItem<Type extends Record<string, unknown>>(
       {
         cacheKeys: getMutableKeys(Array.from(cache.keys())),
         getPostgrestFilter,
-        revalidate: (key) => mutate({ ...opts, revalidate: true }),
+        revalidate: (key) => {
+          mutate(key, { ...opts, revalidate: true });
+        },
         mutate: (key, data) => {
           mutate(key, data, { ...opts, revalidate: opts?.revalidate ?? false });
         },

--- a/packages/postgrest-swr/src/cache/use-mutate-item.ts
+++ b/packages/postgrest-swr/src/cache/use-mutate-item.ts
@@ -32,7 +32,9 @@ export function useMutateItem<Type extends Record<string, unknown>>(
       {
         cacheKeys: getMutableKeys(Array.from(cache.keys())),
         getPostgrestFilter,
-        revalidate: (key) => mutate({ ...opts, revalidate: true }),
+        revalidate: (key) => {
+          mutate(key, { ...opts, revalidate: true });
+        },
         mutate: (key, data) => {
           mutate(key, data, {
             ...opts,

--- a/packages/postgrest-swr/src/cache/use-upsert-item.ts
+++ b/packages/postgrest-swr/src/cache/use-upsert-item.ts
@@ -30,7 +30,9 @@ export function useUpsertItem<Type extends Record<string, unknown>>(
       {
         cacheKeys: getMutableKeys(Array.from(cache.keys())),
         getPostgrestFilter,
-        revalidate: (key) => mutate({ ...opts, revalidate: true }),
+        revalidate: (key) => {
+          mutate(key, { ...opts, revalidate: true });
+        },
         mutate: (key, data) => {
           mutate(key, data, {
             ...opts,


### PR DESCRIPTION
when splitting mutate and revalidate, I forgot to pass the key to `mutate`. this pr fixes this and adds a test.

fixes #365 


