### PR TITLE
updates typescript to v5.4.2

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "nextra-theme-docs": "2.13.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.13",

--- a/examples/react-query/package.json
+++ b/examples/react-query/package.json
@@ -81,6 +81,6 @@
     "postcss": "^8.4.14",
     "prettier": "3.0.3",
     "tailwindcss": "3.3.3",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   }
 }

--- a/examples/swr/package.json
+++ b/examples/swr/package.json
@@ -81,6 +81,6 @@
     "postcss": "^8.4.14",
     "prettier": "3.0.3",
     "tailwindcss": "3.3.3",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   }
 }

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -11,7 +11,7 @@
     "eslint-config-universe": "12.0.0"
   },
   "devDependencies": {
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/postgrest-core/package.json
+++ b/packages/postgrest-core/package.json
@@ -68,6 +68,6 @@
     "jest": "29.7.0",
     "ts-jest": "29.1.0",
     "tsup": "8.0.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   }
 }

--- a/packages/postgrest-react-query/package.json
+++ b/packages/postgrest-react-query/package.json
@@ -74,7 +74,7 @@
     "react": "18.2.0",
     "@types/react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   },
   "dependencies": {
     "@supabase-cache-helpers/postgrest-core": "workspace:*"

--- a/packages/postgrest-swr/package.json
+++ b/packages/postgrest-swr/package.json
@@ -78,7 +78,7 @@
     "react-dom": "18.2.0",
     "ts-jest": "29.1.0",
     "tsup": "8.0.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   },
   "dependencies": {
     "@supabase-cache-helpers/postgrest-core": "workspace:*",

--- a/packages/storage-core/package.json
+++ b/packages/storage-core/package.json
@@ -55,6 +55,6 @@
     "ts-jest": "29.1.0",
     "@supabase-cache-helpers/tsconfig": "workspace:*",
     "tsup": "8.0.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   }
 }

--- a/packages/storage-react-query/package.json
+++ b/packages/storage-react-query/package.json
@@ -74,7 +74,7 @@
     "react": "18.2.0",
     "@types/react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   },
   "dependencies": {
     "@supabase-cache-helpers/storage-core": "workspace:*"

--- a/packages/storage-swr/package.json
+++ b/packages/storage-swr/package.json
@@ -73,7 +73,7 @@
     "react": "18.2.0",
     "@types/react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.3.2"
+    "typescript": "5.4.2"
   },
   "dependencies": {
     "@supabase-cache-helpers/storage-core": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 8.54.0
       eslint-config-next:
         specifier: 14.1.0
-        version: 14.1.0(eslint@8.54.0)(typescript@5.3.2)
+        version: 14.1.0(eslint@8.54.0)(typescript@5.4.2)
       next:
         specifier: 14.1.0
         version: 14.1.0(react-dom@18.2.0)(react@18.2.0)
@@ -60,8 +60,8 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
     devDependencies:
       autoprefixer:
         specifier: ^10.4.13
@@ -255,7 +255,7 @@ importers:
         version: 8.54.0
       eslint-config-next:
         specifier: 13.5.6
-        version: 13.5.6(eslint@8.54.0)(typescript@5.3.2)
+        version: 13.5.6(eslint@8.54.0)(typescript@5.4.2)
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.54.0)
@@ -275,8 +275,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   examples/swr:
     dependencies:
@@ -460,7 +460,7 @@ importers:
         version: 8.54.0
       eslint-config-next:
         specifier: 13.5.6
-        version: 13.5.6(eslint@8.54.0)(typescript@5.3.2)
+        version: 13.5.6(eslint@8.54.0)(typescript@5.4.2)
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.54.0)
@@ -480,8 +480,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/eslint-config-custom:
     dependencies:
@@ -493,17 +493,17 @@ importers:
         version: 1.10.16(eslint@8.54.0)
       eslint-config-universe:
         specifier: 12.0.0
-        version: 12.0.0(eslint@8.54.0)(prettier@3.2.5)(typescript@5.3.2)
+        version: 12.0.0(eslint@8.54.0)(prettier@3.2.0)(typescript@5.4.2)
     devDependencies:
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/jest-presets:
     dependencies:
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(jest@29.7.0)(typescript@5.3.3)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
 
   packages/postgrest-core:
     dependencies:
@@ -558,13 +558,13 @@ importers:
         version: 29.7.0
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(typescript@5.3.2)
+        version: 8.0.0(typescript@5.4.2)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/postgrest-react-query:
     dependencies:
@@ -625,13 +625,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(typescript@5.3.2)
+        version: 8.0.0(typescript@5.4.2)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/postgrest-swr:
     dependencies:
@@ -695,13 +695,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(typescript@5.3.2)
+        version: 8.0.0(typescript@5.4.2)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/prettier-config:
     devDependencies:
@@ -743,13 +743,13 @@ importers:
         version: 29.7.0
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(typescript@5.3.2)
+        version: 8.0.0(typescript@5.4.2)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/storage-react-query:
     dependencies:
@@ -810,13 +810,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(typescript@5.3.2)
+        version: 8.0.0(typescript@5.4.2)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/storage-swr:
     dependencies:
@@ -877,13 +877,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-jest:
         specifier: 29.1.0
-        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2)
+        version: 29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2)
       tsup:
         specifier: 8.0.0
-        version: 8.0.0(typescript@5.3.2)
+        version: 8.0.0(typescript@5.4.2)
       typescript:
-        specifier: 5.3.2
-        version: 5.3.2
+        specifier: 5.4.2
+        version: 5.4.2
 
   packages/tsconfig: {}
 
@@ -1648,7 +1648,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.19.8:
@@ -1657,7 +1656,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.19.8:
@@ -1666,7 +1664,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.19.8:
@@ -1675,7 +1672,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.19.8:
@@ -1684,7 +1680,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.19.8:
@@ -1693,7 +1688,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.19.8:
@@ -1702,7 +1696,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.19.8:
@@ -1711,7 +1704,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.19.8:
@@ -1720,7 +1712,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.19.8:
@@ -1729,7 +1720,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.19.8:
@@ -1738,7 +1728,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.19.8:
@@ -1747,7 +1736,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.19.8:
@@ -1756,7 +1744,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.19.8:
@@ -1765,7 +1752,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.19.8:
@@ -1774,7 +1760,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.19.8:
@@ -1783,7 +1768,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.19.8:
@@ -1792,7 +1776,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.19.8:
@@ -1801,7 +1784,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.19.8:
@@ -1810,7 +1792,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.19.8:
@@ -1819,7 +1800,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.19.8:
@@ -1828,7 +1808,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.19.8:
@@ -1837,7 +1816,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.54.0):
@@ -4483,7 +4461,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  /@typescript-eslint/eslint-plugin@6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.54.0)(typescript@5.3.2):
+  /@typescript-eslint/eslint-plugin@6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-GosF4238Tkes2SHPQ1i8f6rMtG6zlKwMEB0abqSJ3Npvos+doIlc/ATG+vX1G9coDF3Ex78zM3heXHLyWEwLUw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -4495,10 +4473,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.9.1
-      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       '@typescript-eslint/scope-manager': 6.8.0
-      '@typescript-eslint/type-utils': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
-      '@typescript-eslint/utils': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/type-utils': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.8.0
       debug: 4.3.4
       eslint: 8.54.0
@@ -4506,13 +4484,13 @@ packages:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.2)
-      typescript: 5.3.2
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.56.0(eslint@8.54.0)(typescript@5.3.2):
+  /@typescript-eslint/parser@5.56.0(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4524,14 +4502,14 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.56.0
       '@typescript-eslint/types': 5.56.0
-      '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.3.2)
+      '@typescript-eslint/typescript-estree': 5.56.0(typescript@5.4.2)
       debug: 4.3.4
       eslint: 8.54.0
-      typescript: 5.3.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser@6.8.0(eslint@8.54.0)(typescript@5.3.2):
+  /@typescript-eslint/parser@6.8.0(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-5tNs6Bw0j6BdWuP8Fx+VH4G9fEPDxnVI7yH1IAPkQH5RUtvKwRoqdecAPdQXv4rSOADAaz1LFBZvZG7VbXivSg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -4543,11 +4521,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.8.0
       '@typescript-eslint/types': 6.8.0
-      '@typescript-eslint/typescript-estree': 6.8.0(typescript@5.3.2)
+      '@typescript-eslint/typescript-estree': 6.8.0(typescript@5.4.2)
       '@typescript-eslint/visitor-keys': 6.8.0
       debug: 4.3.4
       eslint: 8.54.0
-      typescript: 5.3.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4567,7 +4545,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.8.0
     dev: false
 
-  /@typescript-eslint/type-utils@6.8.0(eslint@8.54.0)(typescript@5.3.2):
+  /@typescript-eslint/type-utils@6.8.0(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-RYOJdlkTJIXW7GSldUIHqc/Hkto8E+fZN96dMIFhuTJcQwdRoGN2rEWA8U6oXbLo0qufH7NPElUb+MceHtz54g==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -4577,12 +4555,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.8.0(typescript@5.3.2)
-      '@typescript-eslint/utils': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/typescript-estree': 6.8.0(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       debug: 4.3.4
       eslint: 8.54.0
-      ts-api-utils: 1.0.3(typescript@5.3.2)
-      typescript: 5.3.2
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4596,7 +4574,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.56.0(typescript@5.3.2):
+  /@typescript-eslint/typescript-estree@5.56.0(typescript@5.4.2):
     resolution: {integrity: sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4611,12 +4589,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.3.2)
-      typescript: 5.3.2
+      tsutils: 3.21.0(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree@6.8.0(typescript@5.3.2):
+  /@typescript-eslint/typescript-estree@6.8.0(typescript@5.4.2):
     resolution: {integrity: sha512-ISgV0lQ8XgW+mvv5My/+iTUdRmGspducmQcDw5JxznasXNnZn3SKNrTRuMsEXv+V/O+Lw9AGcQCfVaOPCAk/Zg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -4631,13 +4609,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.2)
-      typescript: 5.3.2
+      ts-api-utils: 1.0.3(typescript@5.4.2)
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@6.8.0(eslint@8.54.0)(typescript@5.3.2):
+  /@typescript-eslint/utils@6.8.0(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-dKs1itdE2qFG4jr0dlYLQVppqTE+Itt7GmIf/vX6CSvsW+3ov8PbWauVKyyfNngokhIO9sKZeRGCUo1+N7U98Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -4648,7 +4626,7 @@ packages:
       '@types/semver': 7.5.4
       '@typescript-eslint/scope-manager': 6.8.0
       '@typescript-eslint/types': 6.8.0
-      '@typescript-eslint/typescript-estree': 6.8.0(typescript@5.3.2)
+      '@typescript-eslint/typescript-estree': 6.8.0(typescript@5.4.2)
       eslint: 8.54.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -6322,7 +6300,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.8
       '@esbuild/win32-ia32': 0.19.8
       '@esbuild/win32-x64': 0.19.8
-    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -6357,7 +6334,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@13.5.6(eslint@8.54.0)(typescript@5.3.2):
+  /eslint-config-next@13.5.6(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-o8pQsUHTo9aHqJ2YiZDym5gQAMRf7O2HndHo/JZeY7TDD+W4hk6Ma8Vw54RHiBeb7OWWO5dPirQB+Is/aVQ7Kg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -6368,7 +6345,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.5.6
       '@rushstack/eslint-patch': 1.4.0
-      '@typescript-eslint/parser': 5.56.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 5.56.0(eslint@8.54.0)(typescript@5.4.2)
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.56.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.54.0)
@@ -6376,13 +6353,13 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.54.0)
       eslint-plugin-react: 7.33.2(eslint@8.54.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
-      typescript: 5.3.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /eslint-config-next@14.1.0(eslint@8.54.0)(typescript@5.3.2):
+  /eslint-config-next@14.1.0(eslint@8.54.0)(typescript@5.4.2):
     resolution: {integrity: sha512-SBX2ed7DoRFXC6CQSLc/SbLY9Ut6HxNB2wPTcoIWjUMd7aF7O/SIE7111L8FdZ9TXsNV4pulUDnfthpyPtbFUg==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -6393,7 +6370,7 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.1.0
       '@rushstack/eslint-patch': 1.4.0
-      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@6.8.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.28.1)(eslint@8.54.0)
@@ -6401,7 +6378,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.54.0)
       eslint-plugin-react: 7.33.2(eslint@8.54.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
-      typescript: 5.3.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -6434,7 +6411,7 @@ packages:
       eslint-plugin-turbo: 1.10.16(eslint@8.54.0)
     dev: false
 
-  /eslint-config-universe@12.0.0(eslint@8.54.0)(prettier@3.2.5)(typescript@5.3.2):
+  /eslint-config-universe@12.0.0(eslint@8.54.0)(prettier@3.2.0)(typescript@5.4.2):
     resolution: {integrity: sha512-78UxGByheyDNL1RhszWYeDzWiBaUtLnFSeI20pJI89IXa9OAEZQHzG/iBFpMeaCs7Hqyg0wYJcuCbCx535wB7A==}
     peerDependencies:
       eslint: '>=8.10'
@@ -6443,16 +6420,16 @@ packages:
       prettier:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.54.0)(typescript@5.3.2)
-      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/eslint-plugin': 6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.54.0)(typescript@5.4.2)
+      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       eslint: 8.54.0
       eslint-config-prettier: 8.10.0(eslint@8.54.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.8.0)(eslint@8.54.0)
       eslint-plugin-node: 11.1.0(eslint@8.54.0)
-      eslint-plugin-prettier: 5.0.1(eslint-config-prettier@8.10.0)(eslint@8.54.0)(prettier@3.2.5)
+      eslint-plugin-prettier: 5.0.1(eslint-config-prettier@8.10.0)(eslint@8.54.0)(prettier@3.2.0)
       eslint-plugin-react: 7.33.2(eslint@8.54.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
-      prettier: 3.2.5
+      prettier: 3.2.0
     transitivePeerDependencies:
       - '@types/eslint'
       - eslint-import-resolver-typescript
@@ -6538,7 +6515,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.56.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 5.56.0(eslint@8.54.0)(typescript@5.4.2)
       debug: 3.2.7
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
@@ -6567,7 +6544,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       debug: 3.2.7
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
@@ -6597,7 +6574,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.56.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 5.56.0(eslint@8.54.0)(typescript@5.4.2)
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -6631,7 +6608,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 6.8.0(eslint@8.54.0)(typescript@5.4.2)
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -6695,7 +6672,7 @@ packages:
       semver: 6.3.1
     dev: false
 
-  /eslint-plugin-prettier@5.0.1(eslint-config-prettier@8.10.0)(eslint@8.54.0)(prettier@3.2.5):
+  /eslint-plugin-prettier@5.0.1(eslint-config-prettier@8.10.0)(eslint@8.54.0)(prettier@3.2.0):
     resolution: {integrity: sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -6711,7 +6688,7 @@ packages:
     dependencies:
       eslint: 8.54.0
       eslint-config-prettier: 8.10.0(eslint@8.54.0)
-      prettier: 3.2.5
+      prettier: 3.2.0
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
     dev: false
@@ -10240,13 +10217,6 @@ packages:
     resolution: {integrity: sha512-/vBUecTGaPlRVwyZVROVC58bYIScqaoEJzZmzQXXrZOzqn0TwWz0EnOozOlFO/YAImRnb7XsKpTCd3m1SjS2Ww==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
-
-  /prettier@3.2.5:
-    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: false
 
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -11546,13 +11516,13 @@ packages:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
 
-  /ts-api-utils@1.0.3(typescript@5.3.2):
+  /ts-api-utils@1.0.3(typescript@5.4.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.3.2
+      typescript: 5.4.2
     dev: false
 
   /ts-dedent@2.2.0:
@@ -11563,7 +11533,7 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  /ts-jest@29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.3.2):
+  /ts-jest@29.1.0(@babel/core@7.24.0)(esbuild@0.19.8)(jest@29.7.0)(typescript@5.4.2):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -11594,43 +11564,8 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.3.2
+      typescript: 5.4.2
       yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.1.0(@babel/core@7.24.0)(jest@29.7.0)(typescript@5.3.3):
-    resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.24.0
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.3.3
-      yargs-parser: 21.1.1
-    dev: false
 
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
@@ -11646,7 +11581,7 @@ packages:
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsup@8.0.0(typescript@5.3.2):
+  /tsup@8.0.0(typescript@5.4.2):
     resolution: {integrity: sha512-9rOGn8LsFn2iAg2pCB1jnH7ygVuGjlzIomjw0jKXUxAii3iL5cXgm0jZMPKfFH1bSAjQovJ1DUVPSw+oDuIu8A==}
     engines: {node: '>=18'}
     hasBin: true
@@ -11679,20 +11614,20 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.3.2
+      typescript: 5.4.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils@3.21.0(typescript@5.3.2):
+  /tsutils@3.21.0(typescript@5.4.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.3.2
+      typescript: 5.4.2
 
   /tty-table@4.2.3:
     resolution: {integrity: sha512-Fs15mu0vGzCrj8fmJNP7Ynxt5J7praPXqFN0leZeZBXJwkMxv9cb2D454k1ltrtUSJbZ4yH4e0CynsHLxmUfFA==}
@@ -11846,16 +11781,10 @@ packages:
       for-each: 0.3.3
       is-typed-array: 1.1.12
 
-  /typescript@5.3.2:
-    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
+  /typescript@5.4.2:
+    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
Hi there! This should close #401  and #405 (please refer to my breakdown in #401 for more context)

I discovered a similar issue with Tanstack Query and the resolution was updating Typescript to the latest stable version v5.4.2. 

https://github.com/TanStack/query/issues/6318

After updating and building this package, typesafety was restored with moduleResolution bundler. I think we got pretty lucky with the timing here since this update from TS was just released! 

For parity, I went ahead and matched all TS versions in all packages, I hope that's okay. Other than that...this was quite an easy fix after staring at it for a second! 