### PR TITLE
fix: use only `mutate(key)` for revalidation

### DIFF
--- a/.changeset/real-pants-stare.md
+++ b/.changeset/real-pants-stare.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-swr": patch
+---
+
+fix: revalidation flicker due to undefined data passed to mutate

--- a/packages/postgrest-swr/src/cache/use-delete-item.ts
+++ b/packages/postgrest-swr/src/cache/use-delete-item.ts
@@ -32,7 +32,7 @@ export function useDeleteItem<Type extends Record<string, unknown>>(
         cacheKeys: getMutableKeys(Array.from(cache.keys())),
         getPostgrestFilter,
         revalidate: (key) => {
-          mutate(key, null, { ...opts, revalidate: true });
+          mutate(key);
         },
         mutate: (key, data) => {
           mutate(key, data, { ...opts, revalidate: opts?.revalidate ?? false });

--- a/packages/postgrest-swr/src/cache/use-mutate-item.ts
+++ b/packages/postgrest-swr/src/cache/use-mutate-item.ts
@@ -34,7 +34,7 @@ export function useMutateItem<Type extends Record<string, unknown>>(
         cacheKeys: getMutableKeys(Array.from(cache.keys())),
         getPostgrestFilter,
         revalidate: (key) => {
-          mutate(key, null, { ...opts, revalidate: true });
+          mutate(key);
         },
         mutate: (key, data) => {
           mutate(key, data, {

--- a/packages/postgrest-swr/src/cache/use-upsert-item.ts
+++ b/packages/postgrest-swr/src/cache/use-upsert-item.ts
@@ -32,7 +32,7 @@ export function useUpsertItem<Type extends Record<string, unknown>>(
         cacheKeys: getMutableKeys(Array.from(cache.keys())),
         getPostgrestFilter,
         revalidate: (key) => {
-          mutate(key, null, { ...opts, revalidate: true });
+          mutate(key);
         },
         mutate: (key, data) => {
           mutate(key, data, {


### PR DESCRIPTION
passing `data` causes the query to be set to `undefined` until the new
data arrives.

cant see a way to apply the options [as per swr docs](https://swr.vercel.app/docs/mutation.en-US#revalidation) or types of the
function.

fixes #467 
