### PR TITLE
fix: select param parsing when embedding begins with another embedding

### DIFF
--- a/.changeset/lazy-bananas-tap.md
+++ b/.changeset/lazy-bananas-tap.md
@@ -1,0 +1,3 @@
+---
+"@supabase-cache-helpers/postgrest-core": patch
+---

--- a/packages/postgrest-core/src/lib/parse-select-param.ts
+++ b/packages/postgrest-core/src/lib/parse-select-param.ts
@@ -14,8 +14,12 @@ export const parseSelectParam = (s: string, currentPath?: Path): Path[] => {
         '2': 'selectedColumns',
         '3': null,
       },
-    }).map(item => {
-      if (item.name === 'tableName' && item.value && !item.value.startsWith(',')) {
+    }).map((item) => {
+      if (
+        item.name === 'tableName' &&
+        item.value &&
+        !item.value.startsWith(',')
+      ) {
         item.value = ',' + item.value;
       }
       return item;

--- a/packages/postgrest-core/src/lib/parse-select-param.ts
+++ b/packages/postgrest-core/src/lib/parse-select-param.ts
@@ -7,13 +7,18 @@ export const parseSelectParam = (s: string, currentPath?: Path): Path[] => {
 
   let result;
   try {
-    result = XRegExp.matchRecursive(`,${s}`, ',[^,]*\\(', '\\)', 'g', {
+    result = XRegExp.matchRecursive(`,${s}`, '([^,\\(]+)\\(', '\\)', 'g', {
       valueNames: {
         '0': null,
         '1': 'tableName',
         '2': 'selectedColumns',
         '3': null,
       },
+    }).map(item => {
+      if (item.name === 'tableName' && item.value && !item.value.startsWith(',')) {
+        item.value = ',' + item.value;
+      }
+      return item;
     });
   } catch (e) {
     const path = currentPath?.path

--- a/packages/postgrest-core/tests/lib/parse-select-param.spec.ts
+++ b/packages/postgrest-core/tests/lib/parse-select-param.spec.ts
@@ -39,7 +39,7 @@ describe('parseSelectParam', () => {
   it('should work for special case', () => {
     expect(
       parseSelectParam(
-        'id,team_members:team_member_team_id_fkey(team_id,employee!team_member_employee_id_fkey(id,display_name,user_id))',
+        'id,team_members:team_member_team_id_fkey(employee!team_member_employee_id_fkey(id,display_name,user_id),team_id)',
       ),
     ).toEqual([
       {


### PR DESCRIPTION
Fixes #437

Also modifies `parse-select-param.spec.ts` special case test to have two embeddings back-to-back.