### PR TITLE
Fix JSX typo in configuration.mdx

### DIFF
--- a/docs/pages/configuration.mdx
+++ b/docs/pages/configuration.mdx
@@ -14,6 +14,7 @@ Supabase Cache Helpers does a decent job at keeping your data up-to-date. This a
                 value={{
                     revalidateIfStale: false,
                     revalidateOnFocus: false,
+                }}
             >
             ...
             </SWRConfig>


### PR DESCRIPTION
I believe there is a typo in the JSX syntax, which is causing the syntax highlighting to break