### PR TITLE
Feat: Add transformer option to use-query

### DIFF
--- a/packages/postgrest-react-query/src/query/build-query-opts.ts
+++ b/packages/postgrest-react-query/src/query/build-query-opts.ts
@@ -8,13 +8,23 @@ import type { UseQueryOptions as UseReactQueryOptions } from '@tanstack/react-qu
 
 import { encode } from '../lib/key';
 
-export function buildQueryOpts<Result>(
+export function buildQueryOpts<Result, TransformedResult = Result>(
   query: PromiseLike<AnyPostgrestResponse<Result>>,
   config?: Omit<
-    UseReactQueryOptions<AnyPostgrestResponse<Result>, PostgrestError>,
+    UseReactQueryOptions<
+      AnyPostgrestResponse<TransformedResult>,
+      PostgrestError
+    >,
     'queryKey' | 'queryFn'
-  >,
-): UseReactQueryOptions<AnyPostgrestResponse<Result>, PostgrestError> {
+  > & {
+    transformer?: (
+      data: AnyPostgrestResponse<Result>['data']
+    ) => TransformedResult;
+  }
+): UseReactQueryOptions<
+  AnyPostgrestResponse<TransformedResult>,
+  PostgrestError
+> {
   return {
     queryKey: encode<Result>(query, false),
     queryFn: async ({ signal }) => {
@@ -24,7 +34,14 @@ export function buildQueryOpts<Result>(
       if (isPostgrestBuilder(query)) {
         query = query.throwOnError();
       }
-      return await query;
+      const result = await query;
+      if (config?.transformer && result.error === null) {
+        return {
+          ...result,
+          data: config.transformer(result.data),
+        };
+      }
+      return result as AnyPostgrestResponse<TransformedResult>;
     },
     ...config,
   };

--- a/packages/postgrest-react-query/src/query/use-query.ts
+++ b/packages/postgrest-react-query/src/query/use-query.ts
@@ -76,65 +76,88 @@ export type UseQueryAnyReturn<Result> = Omit<
  * React hook to execute a PostgREST query and return a single item response.
  *
  * @param {PromiseLike<PostgrestSingleResponse<Result>>} query A promise that resolves to a PostgREST single item response.
- * @param {Omit<UseReactQueryOptions<PostgrestSingleResponse<Result>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
- * @returns {UseQuerySingleReturn<Result>} The hook result containing the single item response data.
+ * @param {Omit<UseReactQueryOptions<PostgrestSingleResponse<TransformedResult>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
+ * @returns {UseQuerySingleReturn<TransformedResult>} The hook result containing the single item response data.
  */
-function useQuery<Result>(
+function useQuery<Result, TransformedResult = Result>(
   query: PromiseLike<PostgrestSingleResponse<Result>>,
   config?: Omit<
-    UseReactQueryOptions<PostgrestSingleResponse<Result>, PostgrestError>,
+    UseReactQueryOptions<
+      PostgrestSingleResponse<TransformedResult>,
+      PostgrestError
+    >,
     'queryKey' | 'queryFn'
-  >,
-): UseQuerySingleReturn<Result>;
+  > & {
+    transformer?: (
+      data: PostgrestSingleResponse<Result>['data']
+    ) => TransformedResult;
+  }
+): UseQuerySingleReturn<TransformedResult>;
 /**
  * React hook to execute a PostgREST query and return a maybe single item response.
  *
  * @param {PromiseLike<PostgrestMaybeSingleResponse<Result>>} query A promise that resolves to a PostgREST maybe single item response.
- * @param {Omit<UseReactQueryOptions<PostgrestMaybeSingleResponse<Result>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
- * @returns {UseQueryMaybeSingleReturn<Result>} The hook result containing the maybe single item response data.
+ * @param {Omit<UseReactQueryOptions<PostgrestMaybeSingleResponse<TransformedResult>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
+ * @returns {UseQueryMaybeSingleReturn<TransformedResult>} The hook result containing the maybe single item response data.
  */
-function useQuery<Result>(
+function useQuery<Result, TransformedResult = Result>(
   query: PromiseLike<PostgrestMaybeSingleResponse<Result>>,
   config?: Omit<
-    UseReactQueryOptions<PostgrestMaybeSingleResponse<Result>, PostgrestError>,
+    UseReactQueryOptions<
+      PostgrestMaybeSingleResponse<TransformedResult>,
+      PostgrestError
+    >,
     'queryKey' | 'queryFn'
-  >,
-): UseQueryMaybeSingleReturn<Result>;
+  > & {
+    transformer?: (
+      data: PostgrestMaybeSingleResponse<Result>['data']
+    ) => TransformedResult;
+  }
+): UseQueryMaybeSingleReturn<TransformedResult>;
 /**
  * React hook to execute a PostgREST query.
  *
  * @template Result The expected response data type.
  * @param {PromiseLike<PostgrestResponse<Result>>} query A promise that resolves to a PostgREST response.
- * @param {Omit<UseReactQueryOptions<PostgrestResponse<Result>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
- * @returns {UseQueryReturn<Result>} The hook result containing the response data.
+ * @param {Omit<UseReactQueryOptions<PostgrestResponse<TransformedResult>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
+ * @returns {UseQueryReturn<TransformedResult>} The hook result containing the response data.
  */
-function useQuery<Result>(
+function useQuery<Result, TransformedResult = Result>(
   query: PromiseLike<PostgrestResponse<Result>>,
   config?: Omit<
-    UseReactQueryOptions<PostgrestResponse<Result>, PostgrestError>,
+    UseReactQueryOptions<PostgrestResponse<TransformedResult>, PostgrestError>,
     'queryKey' | 'queryFn'
-  >,
-): UseQueryReturn<Result>;
+  > & {
+    transformer?: (data: PostgrestResponse<Result>['data']) => TransformedResult;
+  }
+): UseQueryReturn<TransformedResult>;
 
 /**
  * React hook to execute a PostgREST query.
  *
  * @template Result The expected response data type.
  * @param {PromiseLike<AnyPostgrestResponse<Result>>} query A promise that resolves to a PostgREST response of any kind.
- * @param {Omit<UseReactQueryOptions<AnyPostgrestResponse<Result>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
- * @returns {UseQueryAnyReturn<Result>} The hook result containing the response data.
+ * @param {Omit<UseReactQueryOptions<AnyPostgrestResponse<TransformedResult>, PostgrestError>, 'queryKey' | 'queryFn'>} [config] The React Query options.
+ * @returns {UseQueryAnyReturn<TransformedResult>} The hook result containing the response data.
  */
-function useQuery<Result>(
+function useQuery<Result, TransformedResult = Result>(
   query: PromiseLike<AnyPostgrestResponse<Result>>,
   config?: Omit<
-    UseReactQueryOptions<AnyPostgrestResponse<Result>, PostgrestError>,
+    UseReactQueryOptions<
+      AnyPostgrestResponse<TransformedResult>,
+      PostgrestError
+    >,
     'queryKey' | 'queryFn'
-  >,
-): UseQueryAnyReturn<Result> {
+  > & {
+    transformer?: (
+      data: AnyPostgrestResponse<Result>['data']
+    ) => TransformedResult;
+  }
+): UseQueryAnyReturn<TransformedResult> {
   const { data, ...rest } = useReactQuery<
-    AnyPostgrestResponse<Result>,
+    AnyPostgrestResponse<TransformedResult>,
     PostgrestError
-  >(buildQueryOpts<Result>(query, config));
+  >(buildQueryOpts<Result, TransformedResult>(query, config));
 
   return { data: data?.data, count: data?.count ?? null, ...rest };
 }


### PR DESCRIPTION
## Issue

https://github.com/psteinroe/supabase-cache-helpers/issues/245

## Overview

I've added a transformer option to use-query. This allows you to transform data, such as converting from snake_case to camelCase.

## Capture

| Without Transformer | With Transformer | Transformer Arguments |
|-|-|-|
|<img width="383" alt="スクリーンショット 2024-09-12 22 17 33" src="https://github.com/user-attachments/assets/69601d7f-efda-4ce7-bee9-fd880ddb0f38">|<img width="375" alt="スクリーンショット 2024-09-12 22 17 42" src="https://github.com/user-attachments/assets/8fb3b765-0a86-484b-867b-07f7ce2ec922">|<img width="368" alt="スクリーンショット 2024-09-12 22 17 49" src="https://github.com/user-attachments/assets/97809107-189b-4db4-83c8-c1cee35ce53c">|

<details>

<summary>CODE: snakeToCamel function</summary>

```typescript

export type SnakeToCamelCase<S extends string> =
  S extends `${infer T}_${infer U}`
    ? `${Lowercase<T>}${Capitalize<SnakeToCamelCase<U>>}`
    : S;
export type SnakeToCamelCaseNested<T> = T extends (infer U)[]
  ? SnakeToCamelCaseNested<U>[]
  : T extends object
    ? {
        [K in keyof T as SnakeToCamelCase<K & string>]: SnakeToCamelCaseNested<
          T[K]
        >;
      }
    : T;

export const snakeToCamel = <
  T extends Record<string, unknown> | readonly Record<string, unknown>[],
>(
  request: T
) => camelcaseKeys(request) as unknown as SnakeToCamelCaseNested<T>;
```

</details>

## Additional Notes
I'm a junior engineer. This is my first contribution to an open-source project. I'm eager to receive feedback on my work. I'm very interested in Supabase and would love to work on other issues if there are any.