### PR TITLE
fix: allow useQuery (react-query version) to return a union

### DIFF
--- a/.changeset/tame-planes-report.md
+++ b/.changeset/tame-planes-report.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-react-query": minor
+---
+
+fix: retain union type in useQuery result

--- a/packages/postgrest-react-query/src/query/use-query.ts
+++ b/packages/postgrest-react-query/src/query/use-query.ts
@@ -13,11 +13,20 @@ import {
 
 import { buildQueryOpts } from './build-query-opts';
 
+
+/**
+ * Applies Omit over a union, while preserving its union-ness.
+ */
+type DistributiveOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never;
+
+
 /**
  * Represents the return value of the `useQuery` hook when `query` is expected to return
  * a single row.
  */
-export type UseQuerySingleReturn<Result> = Omit<
+export type UseQuerySingleReturn<Result> = DistributiveOmit<
   UseReactQueryResult<PostgrestSingleResponse<Result>['data'], PostgrestError>,
   'refetch'
 > &
@@ -31,7 +40,7 @@ export type UseQuerySingleReturn<Result> = Omit<
  * Represents the return value of the `useQuery` hook when `query` is expected to return
  * either a single row or an empty response.
  */
-export type UseQueryMaybeSingleReturn<Result> = Omit<
+export type UseQueryMaybeSingleReturn<Result> = DistributiveOmit<
   UseReactQueryResult<
     PostgrestMaybeSingleResponse<Result>['data'],
     PostgrestError
@@ -48,7 +57,7 @@ export type UseQueryMaybeSingleReturn<Result> = Omit<
  * Represents the return value of the `useQuery` hook when `query` is expected to return
  * one or more rows.
  */
-export type UseQueryReturn<Result> = Omit<
+export type UseQueryReturn<Result> = DistributiveOmit<
   UseReactQueryResult<PostgrestResponse<Result>['data'], PostgrestError>,
   'refetch'
 > &
@@ -62,7 +71,7 @@ export type UseQueryReturn<Result> = Omit<
  * Represents the return value of the `useQuery` hook when the type of the query response
  * is not known.
  */
-export type UseQueryAnyReturn<Result> = Omit<
+export type UseQueryAnyReturn<Result> = DistributiveOmit<
   UseReactQueryResult<AnyPostgrestResponse<Result>['data'], PostgrestError>,
   'refetch'
 > &
@@ -131,12 +140,24 @@ function useQuery<Result>(
     'queryKey' | 'queryFn'
   >,
 ): UseQueryAnyReturn<Result> {
-  const { data, ...rest } = useReactQuery<
-    AnyPostgrestResponse<Result>,
-    PostgrestError
-  >(buildQueryOpts<Result>(query, config));
+  const result = useReactQuery<AnyPostgrestResponse<Result>, PostgrestError>(
+    buildQueryOpts<Result>(query, config)
+  );
 
-  return { data: data?.data, count: data?.count ?? null, ...rest };
+  // isPending and isLoadingError are the only cases in which no data is present
+  if (result.isPending || result.isLoadingError) {
+    return {
+      ...result,
+      data: undefined,
+      count: null,
+    };
+  }
+
+  return {
+    ...result,
+    data: result.data?.data,
+    count: result.data?.count,
+  };
 }
 
 export { useQuery };

--- a/packages/postgrest-react-query/src/query/use-query.ts
+++ b/packages/postgrest-react-query/src/query/use-query.ts
@@ -13,14 +13,12 @@ import {
 
 import { buildQueryOpts } from './build-query-opts';
 
-
 /**
  * Applies Omit over a union, while preserving its union-ness.
  */
 type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>
   : never;
-
 
 /**
  * Represents the return value of the `useQuery` hook when `query` is expected to return
@@ -141,7 +139,7 @@ function useQuery<Result>(
   >,
 ): UseQueryAnyReturn<Result> {
   const result = useReactQuery<AnyPostgrestResponse<Result>, PostgrestError>(
-    buildQueryOpts<Result>(query, config)
+    buildQueryOpts<Result>(query, config),
   );
 
   // isPending and isLoadingError are the only cases in which no data is present


### PR DESCRIPTION
PR for #514 

Omit<UseReactQueryResult<...>> caused the union in UseReactQueryResult to dissolve, I added a helper for distributive application of Omit to preserve it.

With the union back, the body / return of useQuery also needed some adjustment to cover the different cases. It's a bit more verbose this way, but also a bit more explicit :)