### PR TITLE
:bug: improve primary key value validation in update fetcher

### DIFF
--- a/.changeset/six-timers-turn.md
+++ b/.changeset/six-timers-turn.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-core": minor
+---
+
+fix update fetcher when primary key value is equal to false or 0

--- a/.changeset/six-timers-turn.md
+++ b/.changeset/six-timers-turn.md
@@ -1,5 +1,5 @@
 ---
-"@supabase-cache-helpers/postgrest-core": minor
+"@supabase-cache-helpers/postgrest-core": patch
 ---
 
 fix update fetcher when primary key value is equal to false or 0

--- a/packages/postgrest-core/src/update-fetcher.ts
+++ b/packages/postgrest-core/src/update-fetcher.ts
@@ -57,7 +57,8 @@ export const buildUpdateFetcher =
     let filterBuilder = qb.update(payload as any, opts); // todo fix type;
     for (const key of primaryKeys) {
       const value = input[key];
-      if (!value)
+      // The value can be 0 or false, so we need to check if it's null or undefined instead of falsy
+      if (value === null || value === undefined)
         throw new Error(`Missing value for primary key ${String(key)}`);
       filterBuilder = filterBuilder.eq(key as string, value);
     }

--- a/packages/postgrest-core/tests/update-fetcher.spec.ts
+++ b/packages/postgrest-core/tests/update-fetcher.spec.ts
@@ -147,4 +147,40 @@ describe('update', () => {
       .maybeSingle();
     expect(data?.username).toEqual(`${testRunPrefix}-username-4`);
   });
+
+  it('should not throw error when primary key value is false', async () => {
+    const qb = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      throwOnError: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    };
+
+    await expect(
+      buildUpdateFetcher(qb as any, ['is_active'], {
+        stripPrimaryKeys: false,
+        queriesForTable: () => [],
+      })({ is_active: false, username: 'testuser' }),
+    ).resolves.not.toThrow();
+    expect(qb.eq).toHaveBeenCalledWith('is_active', false);
+  });
+
+  it('should not throw error when primary key value is 0', async () => {
+    const qb = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      throwOnError: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null }),
+    };
+
+    await expect(
+      buildUpdateFetcher(qb as any, ['id'], {
+        stripPrimaryKeys: false,
+        queriesForTable: () => [],
+      })({ id: 0, username: 'testuser' }),
+    ).resolves.not.toThrow();
+    expect(qb.eq).toHaveBeenCalledWith('id', 0);
+  });
 });


### PR DESCRIPTION
Fix #517 by replacing falsy check by strict `null` & `undefined` validation