### PR TITLE
Implement linked tabs component and update react query configuration

### DIFF
--- a/docs/components/linked-tabs.tsx
+++ b/docs/components/linked-tabs.tsx
@@ -1,0 +1,31 @@
+import { Tabs } from 'nextra/components';
+import React, { ReactNode } from 'react';
+import { useTabContext } from './tab-context';
+
+interface LinkedTabsProps {
+  id: string;
+  items: string[];
+  children: ReactNode;
+}
+
+export const LinkedTabs: React.FC<LinkedTabsProps> = ({
+  id,
+  items,
+  children,
+}) => {
+  const { selectedTabs, setSelectedTab } = useTabContext();
+  const selectedTab = selectedTabs[id] || items[0];
+
+  const index = items.indexOf(selectedTab);
+  const selectedIndex = index !== -1 ? index : 0;
+
+  return (
+    <Tabs
+      items={items}
+      selectedIndex={selectedIndex}
+      onChange={(index: number) => setSelectedTab(id, items[index])}
+    >
+      {children}
+    </Tabs>
+  );
+};

--- a/docs/components/tab-context.tsx
+++ b/docs/components/tab-context.tsx
@@ -1,9 +1,9 @@
 import {
+  ReactNode,
   createContext,
   useContext,
-  useState,
   useEffect,
-  ReactNode,
+  useState,
 } from 'react';
 
 interface TabContextType {

--- a/docs/components/tab-context.tsx
+++ b/docs/components/tab-context.tsx
@@ -1,0 +1,67 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from 'react';
+
+interface TabContextType {
+  selectedTabs: { [key: string]: string };
+  setSelectedTab: (id: string, tab: string) => void;
+}
+
+const TabContext = createContext<TabContextType>({
+  selectedTabs: {},
+  setSelectedTab: () => {},
+});
+
+export const useTabContext = () => useContext(TabContext);
+
+interface TabProviderProps {
+  children: ReactNode;
+}
+
+export const TabProvider: React.FC<TabProviderProps> = ({ children }) => {
+  const [selectedTabs, setSelectedTabs] = useState<{ [key: string]: string }>(
+    {},
+  );
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const storedTabs = localStorage.getItem('selectedTabs');
+      if (storedTabs) {
+        try {
+          const parsedTabs = JSON.parse(storedTabs) as {
+            [key: string]: string;
+          };
+          setSelectedTabs(parsedTabs);
+        } catch (error) {
+          console.error(
+            'Failed to parse selectedTabs from localStorage',
+            error,
+          );
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('selectedTabs', JSON.stringify(selectedTabs));
+    }
+  }, [selectedTabs]);
+
+  const setSelectedTab = (id: string, tab: string) => {
+    setSelectedTabs((prev) => ({
+      ...prev,
+      [id]: tab,
+    }));
+  };
+
+  return (
+    <TabContext.Provider value={{ selectedTabs, setSelectedTab }}>
+      {children}
+    </TabContext.Provider>
+  );
+};

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,12 +1,13 @@
+import { TabProvider } from '@/components/tab-context';
 import { Analytics } from '@vercel/analytics/react';
 import type { AppProps } from 'next/app';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <TabProvider>
       <Component {...pageProps} />
       <Analytics />
-    </>
+    </TabProvider>
   );
 }
 

--- a/docs/pages/configuration.mdx
+++ b/docs/pages/configuration.mdx
@@ -1,10 +1,13 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Configuration
 
 Supabase Cache Helpers does a decent job at keeping your data up-to-date. This allows you to deviate from the standard configuration and reduce the number of requests to your backend while keeping your app fresh.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']}
+  id="data-fetcher"
+>
   <Tabs.Tab>
     ```tsx
     function Page() {
@@ -22,8 +25,27 @@ Supabase Cache Helpers does a decent job at keeping your data up-to-date. This a
     ```
   </Tabs.Tab>
   <Tabs.Tab>
+  <Callout emoji="🔗">
+    You can find more details on the [React Query documentation](https://tanstack.com/query/latest/docs/framework/react/quick-start).
+  </Callout>
     ```tsx
-    // TODO
-    ```
+    function Page() {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            staleTime: Infinity,
+            cacheTime: Infinity,
+          },
+        },
+      });
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          {/* Your components */}
+        </QueryClientProvider>
+      );
+    }
+```
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/postgrest/custom-cache-updates.mdx
+++ b/docs/pages/postgrest/custom-cache-updates.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Custom Cache Updates
 
@@ -8,7 +9,7 @@ Sometimes, you will find yourself writing custom cache updates. The library expo
 
 Delete a postgrest entity from the cache. Note that you have to pass a value for all primary keys in the input.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useDeleteItem } from "@supabase-cache-helpers/postgrest-swr";
@@ -43,13 +44,13 @@ Delete a postgrest entity from the cache. Note that you have to pass a value for
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useUpsertItem`
 
 Upsert a postgrest entity into the cache. Note that you have to pass a value for all primary keys in the input.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useUpsertItem } from "@supabase-cache-helpers/postgrest-swr";
@@ -84,4 +85,4 @@ Upsert a postgrest entity into the cache. Note that you have to pass a value for
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/postgrest/getting-started.mdx
+++ b/docs/pages/postgrest/getting-started.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Getting Started
 
@@ -12,16 +13,16 @@ pnpm add @supabase-cache-helpers/postgrest-swr
 
 If your package manager does not install peer dependencies automatically, you will need to install them, too.
 
-<Tabs items={["SWR", "React Query"]}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>`pnpm add swr react @supabase/postgrest-js`</Tabs.Tab>
   <Tabs.Tab>`pnpm add @tanstack/react-query react @supabase/postgrest-js`</Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## Quick Start
 
 Import [`useQuery`](./queries#usequery) and define a simple query. The cache key is automatically created from the query. You can pass the SWR- and React Query-native options as a second argument. For pagination and infinite scroll queries, use [`useInfiniteOffsetPaginationQuery`](./queries#useinfiniteoffsetpaginationquery), [`useOffsetInfiniteScrollQuery`](./queries#useoffsetinfinitescrollquery) and [`useCursorInfiniteScrollQuery`](./queries#usecursorinfinitescrollquery).
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useQuery } from "@supabase-cache-helpers/postgrest-swr";
@@ -75,11 +76,11 @@ Import [`useQuery`](./queries#usequery) and define a simple query. The cache key
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 Somewhere in your app, import [`useInsertMutation`](./mutations#useinsertmutation) and define a mutation. For the automatic cache population to work, you need to pass the primary key(s) of the relation as a second argument. To return data from the mutation, pass a `.select('...')` string as the third argument. Pass `null` to skip. The fourth argument is the SWR- and React Query-native `options` object. The mutation will automatically update the query cache of the contact query defined above. Other operations are supported with [`useUpsertMutation`](./mutations#useupsertmutation), [`useUpdateMutation`](./mutations#useupdatemutation) and [`useDeleteMutation`](./mutations#usedeletemutation).
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useInsertMutation } from "@supabase-cache-helpers/postgrest-swr";
@@ -126,13 +127,13 @@ Somewhere in your app, import [`useInsertMutation`](./mutations#useinsertmutatio
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 To subscribe to changes, import [`useSubscription`](./subscriptions#usesubscription) and define a subscription. Use any channel name, and define the subscription as you know it from the Supabase client. For the automatic cache population to work, you need to pass the primary key(s) of the relation. You can pass the SWR and React Query-native mutation options.
 
 The query cache will automatically be updated when new data comes in. If you use [computed / virtual columns](https://postgrest.org/en/stable/api.html?highlight=computed%20columns#computed-virtual-columns) or relations, you can use [`useSubscriptionQuery`](./subscriptions#usesubscriptionquery) to fetch the entity from `PostgREST` before populating the cache with it.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useSubscription } from "@supabase-cache-helpers/postgrest-swr";
@@ -185,4 +186,4 @@ The query cache will automatically be updated when new data comes in. If you use
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/postgrest/mutations.mdx
+++ b/docs/pages/postgrest/mutations.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Mutations
 
@@ -66,7 +67,9 @@ declare type PostgrestMutatorOpts<Type> = {
 
 Insert entities. Will also update the count if applicable. Note that hook requires the user to define the primary keys of the relation, because the items are upserted to the cache to prevent duplicates, e.g. if a subscription is used in parallel.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']}
+  id="data-fetcher"
+    >
   <Tabs.Tab>
     ```tsx
     import { useInsertMutation } from '@supabase-cache-helpers/postgrest-swr'
@@ -115,13 +118,15 @@ Insert entities. Will also update the count if applicable. Note that hook requir
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useUpdateMutation`
 
 Update an entity. Requires the primary keys to be defined explicitly.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']}
+  id="data-fetcher"
+    >
   <Tabs.Tab>
     ```tsx
     import { useUpdateMutation } from '@supabase-cache-helpers/postgrest-swr'
@@ -170,13 +175,15 @@ Update an entity. Requires the primary keys to be defined explicitly.
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useUpsertMutation`
 
 Upsert entities. Requires the primary keys to be defined explicitly. Will also increment the count if an item is inserted.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']}
+id="data-fetcher"
+    >
   <Tabs.Tab>
     ```tsx
     import { useUpsertMutation } from '@supabase-cache-helpers/postgrest-swr'
@@ -225,13 +232,15 @@ Upsert entities. Requires the primary keys to be defined explicitly. Will also i
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useDeleteMutation`
 
 Delete an item by primary key(s). Requires the primary keys to be defined explicitly. Will also update the count of the queries.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']}
+id="data-fetcher"
+    >
   <Tabs.Tab>
     ```tsx
     import { useDeleteMutation } from '@supabase-cache-helpers/postgrest-swr'
@@ -280,4 +289,4 @@ Delete an item by primary key(s). Requires the primary keys to be defined explic
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/postgrest/queries.mdx
+++ b/docs/pages/postgrest/queries.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Queries
 
@@ -13,7 +14,7 @@ client
 
 is parsed into
 
-<Tabs items={["SWR", "React Query"]}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     `postgrest$null$public$contact$select=id%2Cusername%2Cticket_number&username=eq.psteinroe$null$count=exact$head=false$`
   </Tabs.Tab>
@@ -22,7 +23,7 @@ is parsed into
     'select=id%2Cusername%2Cticket_number&username=eq.psteinroe', 'null',
     'count=exact', 'head=false', '' ]`
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 <Callout emoji="⚠️ ">
   Although you can use wildcards (`*`) in your query, their usage is only
@@ -35,7 +36,7 @@ is parsed into
 
 Wrapper around the default data fetching hook that returns the query including the count without any modification of the data. The config parameter of the respective library can be passed as the second argument.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useQuery } from "@supabase-cache-helpers/postgrest-swr";
@@ -85,7 +86,7 @@ Wrapper around the default data fetching hook that returns the query including t
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useInfiniteOffsetPaginationQuery`
 
@@ -95,7 +96,7 @@ Wrapper around the infinite hooks that transforms the data into pages and return
 
 The hook does not use a count query and therefore does not know how many pages there are in total. Instead, it queries one item more than the `pageSize` to know whether there is another page after the current one.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useInfiniteOffsetPaginationQuery } from '@supabase-cache-helpers/postgrest-swr';
@@ -134,7 +135,7 @@ The hook does not use a count query and therefore does not know how many pages t
   // not supported yet :(
   ```
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useOffsetInfiniteScrollQuery`
 
@@ -144,7 +145,7 @@ Wrapper around the infinite hooks that transforms the data into a flat list and 
 
 The hook does not use a count query and therefore does not know how many items there are in total. Instead, it queries one item more than the `pageSize` to know whether there is more data to load.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useOffsetInfiniteScrollQuery } from '@supabase-cache-helpers/postgrest-swr';
@@ -174,7 +175,7 @@ The hook does not use a count query and therefore does not know how many items t
   // not supported yet :(
   ```
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useCursorInfiniteScrollQuery`
 
@@ -195,7 +196,7 @@ For the cursor pagination to work, the query _has to have_:
 
 The hook does not use a count query and therefore does not know how many items there are in total. You can pass `until`, to define until what value data should be loaded. If `until` is not defined, `loadMore` will always be truthy if the last page had a number of elements equal to the page size.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useCursorInfiniteScrollQuery } from '@supabase-cache-helpers/postgrest-swr';
@@ -230,13 +231,13 @@ The hook does not use a count query and therefore does not know how many items t
   // not supported yet :(
   ```
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useOffsetInfiniteQuery`
 
 Wrapper around the infinite hook that returns the query without any modification of the data.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useOffsetInfiniteQuery } from '@supabase-cache-helpers/postgrest-swr';
@@ -266,4 +267,4 @@ Wrapper around the infinite hook that returns the query without any modification
   // not supported yet :(
   ```
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/postgrest/server.mdx
+++ b/docs/pages/postgrest/server.mdx
@@ -1,4 +1,5 @@
 import { Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Server-Side Caching
 
@@ -40,12 +41,14 @@ Most people would build a small wrapper around this to make it easier to use and
 
 Fist, install the dependency:
 
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
+<LinkedTabs items={["npm", "pnpm", "yarn", "bun"]}
+  id="package-manager"
+    >
   <Tabs.Tab>`npm install @supabase-cache-helpers/postgrest-server`</Tabs.Tab>
   <Tabs.Tab>`pnpm add @supabase-cache-helpers/postgrest-server`</Tabs.Tab>
   <Tabs.Tab>`yarn add @supabase-cache-helpers/postgrest-server`</Tabs.Tab>
   <Tabs.Tab>`bun install @supabase-cache-helpers/postgrest-server`</Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 This is how you can make your first cached query:
 

--- a/docs/pages/postgrest/subscriptions.mdx
+++ b/docs/pages/postgrest/subscriptions.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Subscriptions
 
@@ -8,7 +9,7 @@ The cache helpers subscription hooks are simple `useEffect`-based hooks that man
 
 The `useSubscription` hook simply manages a realtime subscription. Upon retrieval of an update, it updates the cache with the retrieved data the same way the mutation hooks do. It exposes all params of the .on() method, including the callback, as well as the mutation options of the respective library. NOTE: Channel names must be unique when using multiple subscription hooks.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useSubscription } from '@supabase-cache-helpers/postgrest-swr';
@@ -67,13 +68,13 @@ The `useSubscription` hook simply manages a realtime subscription. Upon retrieva
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useSubscriptionQuery`
 
 The `useSubscriptionQuery` hook does exactly the same as the `useSubscription` hooks, but instead of updating the cache with the data sent by realtime, it re-fetches the entity from PostgREST and updates the cache with the returned data. The main use case for this hook are [Computed Columns](https://postgrest.org/en/stable/api.html?highlight=computed%20columns#computed-virtual-columns), because these are not sent by realtime. The callback passes an additional property `data: R | T['Row']` which is populated with the data returned by the query. For `DELETE` events, `data` is populated with `old_record` for convenience.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useSubscriptionQuery } from '@supabase-cache-helpers/postgrest-swr';
@@ -134,4 +135,4 @@ The `useSubscriptionQuery` hook does exactly the same as the `useSubscription` h
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/storage/getting-started.mdx
+++ b/docs/pages/storage/getting-started.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Getting Started
 
@@ -6,23 +7,23 @@ import { Callout, Tabs } from 'nextra/components';
 
 Inside your React project directory, run the following:
 
-<Tabs items={["SWR", "React Query"]}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>`pnpm add @supabase-cache-helpers/storage-swr`</Tabs.Tab>
   <Tabs.Tab>`pnpm add @supabase-cache-helpers/storage-react-query`</Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 If your package manager does not install peer dependencies automatically, you will need to install them, too.
 
-<Tabs items={["SWR", "React Query"]}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>`pnpm add swr react @supabase/storage-js`</Tabs.Tab>
   <Tabs.Tab>`pnpm add @tanstack/react-query react @supabase/storage-js`</Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## Quick Start
 
 Import [`useFileUrl`](./queries#usefileurl) and provide bucket id and path of the desired storage object. The cache key is automatically created from the passed details. You can pass the SWR- and React Query-native options. To list all files in a directory, import [`useDirectory`](./queries#usedirectory). If you need all files in a directory and their urls, import [`useDirectoryUrls`](./queries#usedirectoryurls).
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useFileUrl } from "@supabase-cache-helpers/storage-swr";
@@ -73,11 +74,11 @@ Import [`useFileUrl`](./queries#usefileurl) and provide bucket id and path of th
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 To upload file(s), import [`useUpload`](./mutations#useupload). Note that the file queries will be revalidated if the uploaded file is relevant (e.g. if it is uploaded into a directory that is currently queried).
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useUpload } from "@supabase-cache-helpers/storage-swr";
@@ -116,11 +117,11 @@ To upload file(s), import [`useUpload`](./mutations#useupload). Note that the fi
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 Finally, you can remove files and directories with [`useRemoveDirectory`](./mutations#useremovedirectory) and [`useRemoveFiles`](./mutations#useremovefiles).
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useRemoveDirectory } from "@supabase-cache-helpers/storage-swr";
@@ -157,4 +158,4 @@ Finally, you can remove files and directories with [`useRemoveDirectory`](./muta
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/storage/mutations.mdx
+++ b/docs/pages/storage/mutations.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Mutations
 
@@ -15,7 +16,7 @@ const defaultBuildFileName: BuildFileNameFn = ({ path, fileName }) =>
 
 A custom `BuildFileNameFn` can be passed to `config.buildFileName`.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useUpload } from '@supabase-cache-helpers/storage-swr';
@@ -60,13 +61,13 @@ A custom `BuildFileNameFn` can be passed to `config.buildFileName`.
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useRemoveDirectory`
 
 Remove all files in a directory. Does not delete files recursively.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useRemoveDirectory } from '@supabase-cache-helpers/storage-swr';
@@ -105,13 +106,13 @@ Remove all files in a directory. Does not delete files recursively.
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useRemoveFiles`
 
 Remove a list of files by paths.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useRemoveFiles } from '@supabase-cache-helpers/storage-swr';
@@ -150,4 +151,4 @@ Remove a list of files by paths.
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>

--- a/docs/pages/storage/queries.mdx
+++ b/docs/pages/storage/queries.mdx
@@ -1,4 +1,5 @@
 import { Callout, Tabs } from 'nextra/components';
+import { LinkedTabs } from '@/components/linked-tabs';
 
 # Queries
 
@@ -14,7 +15,7 @@ useFileUrl(
 
 is parsed into
 
-<Tabs items={["SWR", "React Query"]}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ` storage$public_contact_files$postgrest-storage-file-url-94/1.jpg `
   </Tabs.Tab>
@@ -22,7 +23,7 @@ is parsed into
     ` [ "storage", "public_contact_files", "postgrest-storage-file-url-94/1.jpg"
     ] `
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useFileUrl`
 
@@ -42,7 +43,7 @@ type URLFetcherConfig = {
 };
 ```
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
     ```tsx
     import { useFileUrl } from '@supabase-cache-helpers/storage-swr';
@@ -93,13 +94,13 @@ type URLFetcherConfig = {
     ```
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useDirectory`
 
 Returns all files in a directory.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
 ```tsx
 import { useDirectory } from "@supabase-cache-helpers/storage-swr";
@@ -147,13 +148,13 @@ function Page() {
 ````
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>
 
 ## `useDirectoryFileUrls`
 
 Convenience hook that returns the files in a directory similar to `useDirectory` but adds the `url` for each.
 
-<Tabs items={['SWR', 'React Query']}>
+<LinkedTabs items={['SWR', 'React Query']} id="data-fetcher">
   <Tabs.Tab>
 ```tsx
 import { useDirectoryFileUrls } from "@supabase-cache-helpers/storage-swr";
@@ -203,4 +204,4 @@ function Page() {
 ````
 
   </Tabs.Tab>
-</Tabs>
+</LinkedTabs>


### PR DESCRIPTION
This pull request introduces a new `LinkedTabs` component and integrates it across various documentation files to enhance tab functionality. The changes include the creation of the `LinkedTabs` component, the `TabContext` for managing tab state, and updating the documentation pages to use the new component.

### Component Creation:
* [`docs/components/linked-tabs.tsx`](diffhunk://#diff-1050986087fe977d1acf4acd32b1bdc5bdd0f32154021976f5281f91ae8a7bb8R1-R31): Added the `LinkedTabs` component to manage tab selection and state using the `useTabContext` hook.
* [`docs/components/tab-context.tsx`](diffhunk://#diff-d79e3cdb6e33c369b425bd82366374a092ce7036bfb11525016aa226ed51806fR1-R67): Created the `TabContext` and `TabProvider` for managing the state of selected tabs across the application.

### Integration into Application:
* [`docs/pages/_app.tsx`](diffhunk://#diff-40d08f613c794b0baed1dd9274a7ac7ecf54dcfb8ae998ac612f70d1cb8c7a43R1-R10): Wrapped the application with `TabProvider` to provide tab state management throughout the app.

### Documentation Updates:
* Updated various `.mdx` files to replace `Tabs` with `LinkedTabs` for consistent tab state management and improved user experience.
  * [`docs/pages/configuration.mdx`](diffhunk://#diff-170de459004a806c41d8b80b538e539b1a0eabe427181b9c8eaa886723c460edR2-R10): Integrated `LinkedTabs` and added a `Callout` for additional information on React Query. [[1]](diffhunk://#diff-170de459004a806c41d8b80b538e539b1a0eabe427181b9c8eaa886723c460edR2-R10) [[2]](diffhunk://#diff-170de459004a806c41d8b80b538e539b1a0eabe427181b9c8eaa886723c460edR28-R51)
  * [`docs/pages/postgrest/custom-cache-updates.mdx`](diffhunk://#diff-fdface3ef8f606634224217c3676ddcd6833a1a76e9b987fd119c1f53a4da226R2): Replaced `Tabs` with `LinkedTabs` for sections on custom cache updates. [[1]](diffhunk://#diff-fdface3ef8f606634224217c3676ddcd6833a1a76e9b987fd119c1f53a4da226R2) [[2]](diffhunk://#diff-fdface3ef8f606634224217c3676ddcd6833a1a76e9b987fd119c1f53a4da226L11-R12) [[3]](diffhunk://#diff-fdface3ef8f606634224217c3676ddcd6833a1a76e9b987fd119c1f53a4da226L46-R53) [[4]](diffhunk://#diff-fdface3ef8f606634224217c3676ddcd6833a1a76e9b987fd119c1f53a4da226L87-R88)
  * [`docs/pages/postgrest/getting-started.mdx`](diffhunk://#diff-74eb3cc75d8791c0fc6d1dca1fdbdfe1ad328b1bd7c96c8ffe91a06b705c414aR2): Updated to use `LinkedTabs` for various examples and instructions. [[1]](diffhunk://#diff-74eb3cc75d8791c0fc6d1dca1fdbdfe1ad328b1bd7c96c8ffe91a06b705c414aR2) [[2]](diffhunk://#diff-74eb3cc75d8791c0fc6d1dca1fdbdfe1ad328b1bd7c96c8ffe91a06b705c414aL15-R25) [[3]](diffhunk://#diff-74eb3cc75d8791c0fc6d1dca1fdbdfe1ad328b1bd7c96c8ffe91a06b705c414aL78-R83) [[4]](diffhunk://#diff-74eb3cc75d8791c0fc6d1dca1fdbdfe1ad328b1bd7c96c8ffe91a06b705c414aL129-R136) [[5]](diffhunk://#diff-74eb3cc75d8791c0fc6d1dca1fdbdfe1ad328b1bd7c96c8ffe91a06b705c414aL188-R189)
  * [`docs/pages/postgrest/mutations.mdx`](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47R2): Integrated `LinkedTabs` for mutation examples and instructions. [[1]](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47R2) [[2]](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47L69-R72) [[3]](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47L118-R129) [[4]](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47L173-R186) [[5]](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47L228-R243) [[6]](diffhunk://#diff-dc537a75ee7b6b92a4e8dde78fd40b26e88a02905b807d733eab0ffd96308f47L283-R292)
  * [`docs/pages/postgrest/queries.mdx`](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752R2): Replaced `Tabs` with `LinkedTabs` for query examples and instructions. [[1]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752R2) [[2]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L16-R17) [[3]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L25-R26) [[4]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L38-R39) [[5]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L88-R89) [[6]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L98-R99) [[7]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L137-R138) [[8]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L147-R148) [[9]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L177-R178) [[10]](diffhunk://#diff-11956ada0ce525701db8f236da6d61629de75aa5f646abcce10dfc03dca78752L198-R199)