### PR TITLE
docs: Update configuration example for React Query

### DIFF
--- a/docs/pages/configuration.mdx
+++ b/docs/pages/configuration.mdx
@@ -35,7 +35,7 @@ Supabase Cache Helpers does a decent job at keeping your data up-to-date. This a
           queries: {
             refetchOnWindowFocus: false,
             staleTime: Infinity,
-            cacheTime: Infinity,
+            gcTime: Infinity,
           },
         },
       });


### PR DESCRIPTION
Update `cacheTime` to `gcTime`

This key was renamed in v5 of React Query
https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#rename-cachetime-to-gctime