### PR TITLE
fix: merge url splitting to unified method that handles self hosted s…

### DIFF
--- a/.changeset/slimy-mails-grab.md
+++ b/.changeset/slimy-mails-grab.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-core": minor
+---
+
+Merge url parsing for rpc and table name and provide consistant parsing for self hosted servers

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -11,7 +11,7 @@ export const getTableFromUrl = (url: string): string => {
   const split = url.toString().split("/");
   // Pop the last part of the path off and remove any params if they exist
   const table = split.pop()?.split("?").shift() as string;
-  // Pop an additional posirtion to check for rpc
+  // Pop an additional position to check for rpc
   const maybeRpc = split.pop() as string;
   // Rejoin the result to include rpc otherwise just table name
   return [maybeRpc === "rpc" ? maybeRpc : null, table]

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -8,7 +8,7 @@
  */
 export const getTableFromUrl = (url: string): string => {
   const split = url.toString().split('/');
-  const table = split.pop() as string;
+  const table = split.pop()?.split('?').shift() as string;
   const maybeRpc = split.pop() as string;
   return [maybeRpc === 'rpc' ? maybeRpc : null, table]
     .filter(Boolean)

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -7,10 +7,14 @@
  * @returns Table name
  */
 export const getTableFromUrl = (url: string): string => {
-  const split = url.toString().split('/');
-  const table = split.pop()?.split('?').shift() as string;
+  // Split the url
+  const split = url.toString().split("/");
+  // Pop the last part of the path off and remove any params if they exist
+  const table = split.pop()?.split("?").shift() as string;
+  // Pop an additional posirtion to check for rpc
   const maybeRpc = split.pop() as string;
-  return [maybeRpc === 'rpc' ? maybeRpc : null, table]
+  // Rejoin the result to include rpc otherwise just table name
+  return [maybeRpc === "rpc" ? maybeRpc : null, table]
     .filter(Boolean)
-    .join('/');
+    .join("/");
 };

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -1,0 +1,10 @@
+/**
+ * Parses a url and returns the table name the url is interacting with.
+ *
+ * For mutations, the .split("?") goes unused.
+ *
+ * @param url The url we are pulling the table name from
+ * @returns Table name
+ */
+export const getTableFromUrl = (url: string): string =>
+  url.split("/").pop()?.split("?").shift() as string;

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -6,5 +6,11 @@
  * @param url The url we are pulling the table name from
  * @returns Table name
  */
-export const getTableFromUrl = (url: string): string =>
-  url.split("/").pop()?.split("?").shift() as string;
+export const getTableFromUrl = (url: string): string => {
+  const split = url.toString().split("/");
+  const table = split.pop() as string;
+  const maybeRpc = split.pop() as string;
+  return [maybeRpc === "rpc" ? maybeRpc : null, table]
+    .filter(Boolean)
+    .join("/");
+};

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -1,16 +1,16 @@
 /**
  * Parses a url and returns the table name the url is interacting with.
  *
- * For mutations, the .split("?") goes unused.
+ * For mutations, the .split('?') goes unused.
  *
  * @param url The url we are pulling the table name from
  * @returns Table name
  */
 export const getTableFromUrl = (url: string): string => {
-  const split = url.toString().split("/");
+  const split = url.toString().split('/');
   const table = split.pop() as string;
   const maybeRpc = split.pop() as string;
-  return [maybeRpc === "rpc" ? maybeRpc : null, table]
+  return [maybeRpc === 'rpc' ? maybeRpc : null, table]
     .filter(Boolean)
-    .join("/");
+    .join('/');
 };

--- a/packages/postgrest-core/src/lib/get-table-from-url.ts
+++ b/packages/postgrest-core/src/lib/get-table-from-url.ts
@@ -8,13 +8,13 @@
  */
 export const getTableFromUrl = (url: string): string => {
   // Split the url
-  const split = url.toString().split("/");
+  const split = url.toString().split('/');
   // Pop the last part of the path off and remove any params if they exist
-  const table = split.pop()?.split("?").shift() as string;
+  const table = split.pop()?.split('?').shift() as string;
   // Pop an additional position to check for rpc
   const maybeRpc = split.pop() as string;
   // Rejoin the result to include rpc otherwise just table name
-  return [maybeRpc === "rpc" ? maybeRpc : null, table]
+  return [maybeRpc === 'rpc' ? maybeRpc : null, table]
     .filter(Boolean)
-    .join("/");
+    .join('/');
 };

--- a/packages/postgrest-core/src/lib/get-table.ts
+++ b/packages/postgrest-core/src/lib/get-table.ts
@@ -1,15 +1,15 @@
 import type {
   PostgrestBuilder,
   PostgrestQueryBuilder,
-} from "@supabase/postgrest-js";
+} from '@supabase/postgrest-js';
 import {
   GenericSchema,
   GenericTable,
-} from "@supabase/postgrest-js/dist/cjs/types";
-import { getTableFromUrl } from "./get-table-from-url";
+} from '@supabase/postgrest-js/dist/cjs/types';
+import { getTableFromUrl } from './get-table-from-url';
 
 export const getTable = (
   query:
     | PostgrestBuilder<any>
     | PostgrestQueryBuilder<GenericSchema, GenericTable>
-): string => getTableFromUrl((query as { url: URL })["url"].pathname);
+): string => getTableFromUrl((query as { url: URL })['url'].pathname);

--- a/packages/postgrest-core/src/lib/get-table.ts
+++ b/packages/postgrest-core/src/lib/get-table.ts
@@ -11,5 +11,5 @@ import { getTableFromUrl } from './get-table-from-url';
 export const getTable = (
   query:
     | PostgrestBuilder<any>
-    | PostgrestQueryBuilder<GenericSchema, GenericTable>
+    | PostgrestQueryBuilder<GenericSchema, GenericTable>,
 ): string => getTableFromUrl((query as { url: URL })['url'].pathname);

--- a/packages/postgrest-core/src/lib/get-table.ts
+++ b/packages/postgrest-core/src/lib/get-table.ts
@@ -1,14 +1,15 @@
 import type {
   PostgrestBuilder,
   PostgrestQueryBuilder,
-} from '@supabase/postgrest-js';
+} from "@supabase/postgrest-js";
 import {
   GenericSchema,
   GenericTable,
-} from '@supabase/postgrest-js/dist/cjs/types';
+} from "@supabase/postgrest-js/dist/cjs/types";
+import { getTableFromUrl } from "./get-table-from-url";
 
 export const getTable = (
   query:
     | PostgrestBuilder<any>
-    | PostgrestQueryBuilder<GenericSchema, GenericTable>,
-): string => (query as { url: URL })['url'].pathname.split('/').pop() as string;
+    | PostgrestQueryBuilder<GenericSchema, GenericTable>
+): string => getTableFromUrl((query as { url: URL })["url"].pathname);

--- a/packages/postgrest-core/src/postgrest-parser.ts
+++ b/packages/postgrest-core/src/postgrest-parser.ts
@@ -1,20 +1,20 @@
-import type { PostgrestBuilder } from "@supabase/postgrest-js";
+import type { PostgrestBuilder } from '@supabase/postgrest-js';
 
-import { encodeObject } from "./lib/encode-object";
-import { isObject } from "./lib/is-object";
-import type { OrderDefinition } from "./lib/query-types";
-import { sortSearchParams } from "./lib/sort-search-param";
+import { encodeObject } from './lib/encode-object';
+import { isObject } from './lib/is-object';
+import type { OrderDefinition } from './lib/query-types';
+import { sortSearchParams } from './lib/sort-search-param';
 import {
   PostgrestQueryParser,
   type PostgrestQueryParserOptions,
-} from "./postgrest-query-parser";
-import { getTableFromUrl } from "./lib/get-table-from-url";
+} from './postgrest-query-parser';
+import { getTableFromUrl } from './lib/get-table-from-url';
 
 export class PostgrestParser<Result> extends PostgrestQueryParser {
   private readonly _url: URL;
   private readonly _headers: { [key: string]: string };
   private readonly _body: object | undefined;
-  private readonly _method: "GET" | "HEAD" | "POST" | "PATCH" | "DELETE";
+  private readonly _method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE';
 
   public readonly queryKey: string;
   public readonly bodyKey: string | undefined;
@@ -31,12 +31,12 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
     fb: PostgrestBuilder<Result>,
     public readonly opts?: PostgrestQueryParserOptions
   ) {
-    super(new URL(fb["url"]).searchParams.toString(), opts);
+    super(new URL(fb['url']).searchParams.toString(), opts);
 
-    this._url = new URL(fb["url"]);
-    this._headers = { ...fb["headers"] };
-    this._body = isObject(fb["body"]) ? { ...fb["body"] } : undefined;
-    this._method = fb["method"];
+    this._url = new URL(fb['url']);
+    this._headers = { ...fb['headers'] };
+    this._body = isObject(fb['body']) ? { ...fb['body'] } : undefined;
+    this._method = fb['method'];
 
     this.queryKey = sortSearchParams(this._url.searchParams).toString();
 
@@ -48,38 +48,38 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
 
     // 'Prefer': return=minimal|representation,count=exact|planned|estimated
     const preferHeaders: Record<string, string> = (
-      this._headers["Prefer"] ?? ""
+      this._headers['Prefer'] ?? ''
     )
-      .split(",")
+      .split(',')
       .reduce<Record<string, string>>((prev, curr) => {
-        const s = curr.split("=");
+        const s = curr.split('=');
         return {
           ...prev,
           [s[0]]: s[1],
         };
       }, {});
-    this.count = preferHeaders["count"] ?? null;
+    this.count = preferHeaders['count'] ?? null;
 
-    this.schema = fb["schema"] as string;
+    this.schema = fb['schema'] as string;
 
-    this.isHead = this._method === "HEAD";
+    this.isHead = this._method === 'HEAD';
 
-    const limit = this._url.searchParams.get("limit");
+    const limit = this._url.searchParams.get('limit');
     this.limit = limit ? Number(limit) : undefined;
-    const offset = this._url.searchParams.get("offset");
+    const offset = this._url.searchParams.get('offset');
     this.offset = offset ? Number(offset) : undefined;
 
     this._url.searchParams.forEach((value, key) => {
-      const split = key.split(".");
-      if (split[split.length === 2 ? 1 : 0] === "order") {
+      const split = key.split('.');
+      if (split[split.length === 2 ? 1 : 0] === 'order') {
         // separated by ,
-        const orderByDefs = value.split(",");
+        const orderByDefs = value.split(',');
         orderByDefs.forEach((def) => {
-          const [column, ascending, nullsFirst] = def.split(".");
+          const [column, ascending, nullsFirst] = def.split('.');
           this.orderBy.push({
-            ascending: ascending === "asc",
+            ascending: ascending === 'asc',
             column,
-            nullsFirst: nullsFirst === "nullsfirst",
+            nullsFirst: nullsFirst === 'nullsfirst',
             foreignTable: split.length === 2 ? split[0] : undefined,
           });
         });
@@ -88,10 +88,10 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
     this.orderByKey = this.orderBy
       .map(
         ({ column, ascending, nullsFirst, foreignTable }) =>
-          `${foreignTable ? `${foreignTable}.` : ""}${column}:${
-            ascending ? "asc" : "desc"
-          }.${nullsFirst ? "nullsFirst" : "nullsLast"}`
+          `${foreignTable ? `${foreignTable}.` : ''}${column}:${
+            ascending ? 'asc' : 'desc'
+          }.${nullsFirst ? 'nullsFirst' : 'nullsLast'}`
       )
-      .join("|");
+      .join('|');
   }
 }

--- a/packages/postgrest-core/src/postgrest-parser.ts
+++ b/packages/postgrest-core/src/postgrest-parser.ts
@@ -90,7 +90,7 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
         ({ column, ascending, nullsFirst, foreignTable }) =>
           `${foreignTable ? `${foreignTable}.` : ''}${column}:${
             ascending ? 'asc' : 'desc'
-          }.${nullsFirst ? 'nullsFirst' : 'nullsLast'}`
+          }.${nullsFirst ? 'nullsFirst' : 'nullsLast'}`,
       )
       .join('|');
   }

--- a/packages/postgrest-core/src/postgrest-parser.ts
+++ b/packages/postgrest-core/src/postgrest-parser.ts
@@ -1,19 +1,20 @@
-import type { PostgrestBuilder } from '@supabase/postgrest-js';
+import type { PostgrestBuilder } from "@supabase/postgrest-js";
 
-import { encodeObject } from './lib/encode-object';
-import { isObject } from './lib/is-object';
-import type { OrderDefinition } from './lib/query-types';
-import { sortSearchParams } from './lib/sort-search-param';
+import { encodeObject } from "./lib/encode-object";
+import { isObject } from "./lib/is-object";
+import type { OrderDefinition } from "./lib/query-types";
+import { sortSearchParams } from "./lib/sort-search-param";
 import {
   PostgrestQueryParser,
   type PostgrestQueryParserOptions,
-} from './postgrest-query-parser';
+} from "./postgrest-query-parser";
+import { getTableFromUrl } from "./lib/get-table-from-url";
 
 export class PostgrestParser<Result> extends PostgrestQueryParser {
   private readonly _url: URL;
   private readonly _headers: { [key: string]: string };
   private readonly _body: object | undefined;
-  private readonly _method: 'GET' | 'HEAD' | 'POST' | 'PATCH' | 'DELETE';
+  private readonly _method: "GET" | "HEAD" | "POST" | "PATCH" | "DELETE";
 
   public readonly queryKey: string;
   public readonly bodyKey: string | undefined;
@@ -28,20 +29,18 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
 
   constructor(
     fb: PostgrestBuilder<Result>,
-    public readonly opts?: PostgrestQueryParserOptions,
+    public readonly opts?: PostgrestQueryParserOptions
   ) {
-    super(new URL(fb['url']).searchParams.toString(), opts);
+    super(new URL(fb["url"]).searchParams.toString(), opts);
 
-    this._url = new URL(fb['url']);
-    this._headers = { ...fb['headers'] };
-    this._body = isObject(fb['body']) ? { ...fb['body'] } : undefined;
-    this._method = fb['method'];
+    this._url = new URL(fb["url"]);
+    this._headers = { ...fb["headers"] };
+    this._body = isObject(fb["body"]) ? { ...fb["body"] } : undefined;
+    this._method = fb["method"];
 
     this.queryKey = sortSearchParams(this._url.searchParams).toString();
 
-    this.table = (this._url.toString().split('/rest/v1/').pop() as string)
-      .split('?')
-      .shift() as string;
+    this.table = getTableFromUrl(this._url.toString());
 
     if (this._body) {
       this.bodyKey = encodeObject(this._body as Record<string, unknown>);
@@ -49,38 +48,38 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
 
     // 'Prefer': return=minimal|representation,count=exact|planned|estimated
     const preferHeaders: Record<string, string> = (
-      this._headers['Prefer'] ?? ''
+      this._headers["Prefer"] ?? ""
     )
-      .split(',')
+      .split(",")
       .reduce<Record<string, string>>((prev, curr) => {
-        const s = curr.split('=');
+        const s = curr.split("=");
         return {
           ...prev,
           [s[0]]: s[1],
         };
       }, {});
-    this.count = preferHeaders['count'] ?? null;
+    this.count = preferHeaders["count"] ?? null;
 
-    this.schema = fb['schema'] as string;
+    this.schema = fb["schema"] as string;
 
-    this.isHead = this._method === 'HEAD';
+    this.isHead = this._method === "HEAD";
 
-    const limit = this._url.searchParams.get('limit');
+    const limit = this._url.searchParams.get("limit");
     this.limit = limit ? Number(limit) : undefined;
-    const offset = this._url.searchParams.get('offset');
+    const offset = this._url.searchParams.get("offset");
     this.offset = offset ? Number(offset) : undefined;
 
     this._url.searchParams.forEach((value, key) => {
-      const split = key.split('.');
-      if (split[split.length === 2 ? 1 : 0] === 'order') {
+      const split = key.split(".");
+      if (split[split.length === 2 ? 1 : 0] === "order") {
         // separated by ,
-        const orderByDefs = value.split(',');
+        const orderByDefs = value.split(",");
         orderByDefs.forEach((def) => {
-          const [column, ascending, nullsFirst] = def.split('.');
+          const [column, ascending, nullsFirst] = def.split(".");
           this.orderBy.push({
-            ascending: ascending === 'asc',
+            ascending: ascending === "asc",
             column,
-            nullsFirst: nullsFirst === 'nullsfirst',
+            nullsFirst: nullsFirst === "nullsfirst",
             foreignTable: split.length === 2 ? split[0] : undefined,
           });
         });
@@ -89,10 +88,10 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
     this.orderByKey = this.orderBy
       .map(
         ({ column, ascending, nullsFirst, foreignTable }) =>
-          `${foreignTable ? `${foreignTable}.` : ''}${column}:${
-            ascending ? 'asc' : 'desc'
-          }.${nullsFirst ? 'nullsFirst' : 'nullsLast'}`,
+          `${foreignTable ? `${foreignTable}.` : ""}${column}:${
+            ascending ? "asc" : "desc"
+          }.${nullsFirst ? "nullsFirst" : "nullsLast"}`
       )
-      .join('|');
+      .join("|");
   }
 }

--- a/packages/postgrest-core/src/postgrest-parser.ts
+++ b/packages/postgrest-core/src/postgrest-parser.ts
@@ -1,6 +1,7 @@
 import type { PostgrestBuilder } from '@supabase/postgrest-js';
 
 import { encodeObject } from './lib/encode-object';
+import { getTableFromUrl } from './lib/get-table-from-url';
 import { isObject } from './lib/is-object';
 import type { OrderDefinition } from './lib/query-types';
 import { sortSearchParams } from './lib/sort-search-param';
@@ -8,7 +9,6 @@ import {
   PostgrestQueryParser,
   type PostgrestQueryParserOptions,
 } from './postgrest-query-parser';
-import { getTableFromUrl } from './lib/get-table-from-url';
 
 export class PostgrestParser<Result> extends PostgrestQueryParser {
   private readonly _url: URL;

--- a/packages/postgrest-core/src/postgrest-parser.ts
+++ b/packages/postgrest-core/src/postgrest-parser.ts
@@ -29,7 +29,7 @@ export class PostgrestParser<Result> extends PostgrestQueryParser {
 
   constructor(
     fb: PostgrestBuilder<Result>,
-    public readonly opts?: PostgrestQueryParserOptions
+    public readonly opts?: PostgrestQueryParserOptions,
   ) {
     super(new URL(fb['url']).searchParams.toString(), opts);
 


### PR DESCRIPTION
…ervers as well as managed supabase.

Here I ensure that url splitting happens consistently between queries and mutations. While doing this, I ensure that the domain does not matter for getting of a table name - we always take the last part of the path after the filters and other params are removed.

This ensures the package can work with any hosted solution regardless of the domain/base path.