### PR TITLE
fix: expose hasMore in offset infinite scroll query

### DIFF
--- a/.changeset/tall-pandas-scroll.md
+++ b/.changeset/tall-pandas-scroll.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-swr": patch
+---
+
+Expose `hasMore` from `useOffsetInfiniteScrollQuery` so consumers can rely on the hook's internal one-extra-row pagination state instead of count-based approximations.

--- a/docs/content/postgrest/queries.md
+++ b/docs/content/postgrest/queries.md
@@ -132,7 +132,7 @@ The hook does not use a count query and therefore does not know how many pages t
 
 Wrapper around the infinite hooks that transforms the data into a flat list and returns a `loadMore` function. The `range` filter is automatically applied based on the `pageSize` parameter. The `SWRConfigurationInfinite` can be passed as second argument.
 
-`loadMore()` is `undefined` if there is no more data to load.
+`loadMore()` is `null` if there is no more data to load. The same state is exposed as `hasMore`, which is derived from the internal one-extra-row pagination response and is independent of the current validation state.
 
 The hook does not use a count query and therefore does not know how many items there are in total. Instead, it queries one item more than the `pageSize` to know whether there is more data to load.
 
@@ -149,7 +149,7 @@ The hook does not use a count query and therefore does not know how many items t
     );
 
     function Page() {
-      const { data, loadMore, isValidating, error } = useOffsetInfiniteScrollQuery(
+      const { data, hasMore, loadMore, isValidating, error } = useOffsetInfiniteScrollQuery(
         () => client
           .from('contact')
           .select('id,username')

--- a/packages/postgrest-swr/src/query/use-offset-infinite-scroll-query.ts
+++ b/packages/postgrest-swr/src/query/use-offset-infinite-scroll-query.ts
@@ -26,6 +26,7 @@ export type SWROffsetInfiniteScrollPostgrestResponse<Result> = Omit<
   'data'
 > & {
   loadMore: null | (() => void);
+  hasMore: boolean;
   data: Result[] | undefined;
 };
 
@@ -48,6 +49,7 @@ export type UseOffsetInfiniteScrollQueryReturn<
   'data'
 > & {
   loadMore: null | (() => void);
+  hasMore: boolean;
   data: Result[] | undefined;
 };
 
@@ -161,6 +163,7 @@ function useOffsetInfiniteScrollQuery<
     data: (Array.isArray(data) ? data : []).flatMap((p) => p.data),
     size,
     setSize,
+    hasMore,
     loadMore: hasMore ? loadMoreFn : null,
     isValidating,
     ...rest,

--- a/packages/postgrest-swr/tests/query/use-offset-infinite-scroll-query.spec.tsx
+++ b/packages/postgrest-swr/tests/query/use-offset-infinite-scroll-query.spec.tsx
@@ -48,7 +48,7 @@ describe('useOffsetInfiniteScrollQuery', { timeout: 20000 }, () => {
   describe('normal query', () => {
     it('should load correctly', async () => {
       function Page() {
-        const { data, loadMore } = useOffsetInfiniteScrollQuery(
+        const { data, hasMore, loadMore } = useOffsetInfiniteScrollQuery(
           () =>
             client
               .from('contact')
@@ -62,6 +62,7 @@ describe('useOffsetInfiniteScrollQuery', { timeout: 20000 }, () => {
             {loadMore && (
               <div data-testid="loadMore" onClick={() => loadMore()} />
             )}
+            <div>{`hasMore: ${hasMore}`}</div>
             <div data-testid="list">
               {(data ?? []).map((p) => (
                 <div key={p.id}>{p.username}</div>
@@ -79,6 +80,7 @@ describe('useOffsetInfiniteScrollQuery', { timeout: 20000 }, () => {
       );
       const list = screen.getByTestId('list');
       expect(list.childElementCount).toEqual(1);
+      expect(screen.getByText('hasMore: true')).toBeDefined();
 
       fireEvent.click(screen.getByTestId('loadMore'));
       await screen.findByText(
@@ -97,6 +99,18 @@ describe('useOffsetInfiniteScrollQuery', { timeout: 20000 }, () => {
       );
 
       expect(list.childElementCount).toEqual(3);
+      expect(screen.getByText('hasMore: true')).toBeDefined();
+
+      fireEvent.click(screen.getByTestId('loadMore'));
+      await screen.findByText(
+        `${testRunPrefix}-username-4`,
+        {},
+        { timeout: 10000 },
+      );
+
+      expect(list.childElementCount).toEqual(4);
+      expect(screen.getByText('hasMore: false')).toBeDefined();
+      expect(screen.queryByTestId('loadMore')).toBeNull();
     });
     it('should allow conditional queries', async () => {
       function Page() {


### PR DESCRIPTION
- Add `hasMore` to `useOffsetInfiniteScrollQuery` return types and hook output
- Keep `loadMore` nullable and derive availability from the hook's one-extra-row pagination state
- Update docs to describe `hasMore` and clarify that `loadMore()` is `null` when no more data exists
- Extend tests to verify `hasMore` toggles correctly and `loadMore` disappears on the last page