### PR TITLE
fix(postgrest-server): support Redis Cluster namespaces

### DIFF
--- a/.changeset/better-ads-fly.md
+++ b/.changeset/better-ads-fly.md
@@ -1,0 +1,5 @@
+---
+"@supabase-cache-helpers/postgrest-server": minor
+---
+
+feat: support redis cluster

--- a/docs/content/postgrest/server.md
+++ b/docs/content/postgrest/server.md
@@ -151,6 +151,9 @@ const client = createClient<Database>(
 const map = new Map();
 
 const redis = new Redis({...});
+// Redis Cluster is also supported:
+// import { Cluster } from 'ioredis';
+// const redis = new Cluster([{ host: '127.0.0.1', port: 6379 }]);
 
 const cache = new QueryCache(ctx, {
     stores: [new MemoryStore({ persistentMap: map }), new RedisStore({ redis })],

--- a/packages/postgrest-server/src/key.ts
+++ b/packages/postgrest-server/src/key.ts
@@ -7,27 +7,36 @@ import {
 
 const SEPARATOR = '$';
 
-export function encode<Result>(
-  query: PromiseLike<AnyPostgrestResponse<Result>>,
-) {
+function getParser<Result>(query: PromiseLike<AnyPostgrestResponse<Result>>) {
   if (!isPostgrestBuilder<Result>(query)) {
     throw new Error('Query is not a PostgrestBuilder');
   }
 
-  const parser = new PostgrestParser<Result>(query);
-  return [
-    parser.schema,
-    parser.table,
-    parser.queryKey,
-    parser.bodyKey ?? 'null',
-    `count=${parser.count}`,
-    `head=${parser.isHead}`,
-    parser.orderByKey,
-  ].join(SEPARATOR);
+  return new PostgrestParser<Result>(query);
 }
 
-export function buildTablePrefix(schema: string, table: string) {
+export function getTablePrefix(schema: string, table: string) {
   return [schema, table].join(SEPARATOR);
+}
+
+export function encode<Result>(
+  query: PromiseLike<AnyPostgrestResponse<Result>>,
+) {
+  const parser = getParser(query);
+  const namespace = getTablePrefix(parser.schema, parser.table);
+
+  return {
+    namespace,
+    key: [
+      parser.schema,
+      parser.table,
+      parser.queryKey,
+      parser.bodyKey ?? 'null',
+      `count=${parser.count}`,
+      `head=${parser.isHead}`,
+      parser.orderByKey,
+    ].join(SEPARATOR),
+  };
 }
 
 /**
@@ -53,5 +62,5 @@ export function buildFilterPattern(
   const escapedPath = escapeGlobChars(filter.path);
   const escapedValue = escapeGlobChars(encodedValue);
   // Pattern: schema$table$*path=eq.value*
-  return `${schema}${SEPARATOR}${table}${SEPARATOR}*${escapedPath}=eq.${escapedValue}*`;
+  return `${getTablePrefix(schema, table)}${SEPARATOR}*${escapedPath}=eq.${escapedValue}*`;
 }

--- a/packages/postgrest-server/src/query-cache.ts
+++ b/packages/postgrest-server/src/query-cache.ts
@@ -1,5 +1,5 @@
 import { Context } from './context';
-import { buildFilterPattern, buildTablePrefix, encode } from './key';
+import { buildFilterPattern, encode, getTablePrefix } from './key';
 import { Value } from './stores/entry';
 import { Store } from './stores/interface';
 import { SwrCache } from './swr-cache';
@@ -77,12 +77,14 @@ export class QueryCache {
       value: ValueType;
     };
   }) {
+    const namespace = getTablePrefix(schema, table);
+
     if (filter) {
       const pattern = buildFilterPattern(schema, table, filter);
-      return this.inner.removeByPattern(pattern);
+      return this.inner.removeByPattern(namespace, pattern);
     }
-    const prefix = buildTablePrefix(schema, table);
-    return this.inner.removeByPrefix(prefix);
+
+    return this.inner.removeByPrefix(namespace, namespace);
   }
 
   /**
@@ -118,16 +120,16 @@ export class QueryCache {
       store?: (result: AnyPostgrestResponse<Result>) => boolean;
     },
   ): Promise<AnyPostgrestResponse<Result>> {
-    const key = encode(query);
+    const { namespace, key } = encode(query);
 
-    const value = await this.inner.get<Result>(key);
+    const value = await this.inner.get<Result>(namespace, key);
 
     if (value) return value;
 
     const result = await this.dedupeQuery(query);
 
     if (!isEmpty(result) && (!opts?.store || opts.store(result))) {
-      await this.inner.set(key, result, opts);
+      await this.inner.set(namespace, key, result, opts);
     }
 
     return result;
@@ -158,8 +160,11 @@ export class QueryCache {
     query: PromiseLike<AnyPostgrestResponse<Result>>,
     opts?: OperationOpts,
   ): Promise<AnyPostgrestResponse<Result>> {
+    const { namespace, key } = encode(query);
+
     return await this.inner.swr(
-      encode(query),
+      namespace,
+      key,
       () => this.dedupeQuery(query),
       opts,
     );
@@ -172,7 +177,7 @@ export class QueryCache {
   private async dedupeQuery<Result>(
     query: PromiseLike<AnyPostgrestResponse<Result>>,
   ): Promise<Value<Result>> {
-    const key = encode(query);
+    const { key } = encode(query);
     try {
       const querying = this.runningQueries.get(key);
       if (querying) {

--- a/packages/postgrest-server/src/stores/interface.ts
+++ b/packages/postgrest-server/src/stores/interface.ts
@@ -18,7 +18,10 @@ export interface Store {
    *
    * The response must be `undefined` for cache misses
    */
-  get<Result>(key: string): Promise<Entry<Result> | undefined>;
+  get<Result>(
+    namespace: string,
+    key: string,
+  ): Promise<Entry<Result> | undefined>;
 
   /**
    * Sets the value for the given key.
@@ -26,21 +29,25 @@ export interface Store {
    * You are responsible for evicting expired values in your store implementation.
    * Use the `entry.staleUntil` (unix milli timestamp) field to configure expiration
    */
-  set<Result>(key: string, value: Entry<Result>): Promise<void>;
+  set<Result>(
+    namespace: string,
+    key: string,
+    value: Entry<Result>,
+  ): Promise<void>;
 
   /**
    * Removes the key from the store.
    */
-  remove(key: string | string[]): Promise<void>;
+  remove(namespace: string, key: string | string[]): Promise<void>;
 
   /**
    * Removes all keys with the given prefix.
    */
-  removeByPrefix(prefix: string): Promise<void>;
+  removeByPrefix(namespace: string, prefix: string): Promise<void>;
 
   /**
    * Removes all keys matching the given glob pattern.
    * Pattern supports `*` as wildcard (e.g., `schema$table$*filter*`).
    */
-  removeByPattern(pattern: string): Promise<void>;
+  removeByPattern(namespace: string, pattern: string): Promise<void>;
 }

--- a/packages/postgrest-server/src/stores/memory.ts
+++ b/packages/postgrest-server/src/stores/memory.ts
@@ -81,7 +81,10 @@ export class MemoryStore implements Store {
     return Promise.resolve();
   }
 
-  public async remove(namespace: string, keys: string | string[]): Promise<void> {
+  public async remove(
+    namespace: string,
+    keys: string | string[],
+  ): Promise<void> {
     const cacheKeys = Array.isArray(keys) ? keys : [keys];
 
     for (const key of cacheKeys) {

--- a/packages/postgrest-server/src/stores/memory.ts
+++ b/packages/postgrest-server/src/stores/memory.ts
@@ -20,6 +20,10 @@ export class MemoryStore implements Store {
     this.capacity = config.capacity;
   }
 
+  private buildCacheKey(namespace: string, key: string): string {
+    return [namespace, key].join('::');
+  }
+
   private setMostRecentlyUsed(
     key: string,
     value: { expires: number; entry: Entry<any> },
@@ -28,30 +32,40 @@ export class MemoryStore implements Store {
     this.state.set(key, value);
   }
 
-  public async get<Result>(key: string): Promise<Entry<Result> | undefined> {
-    const value = this.state.get(key);
+  public async get<Result>(
+    namespace: string,
+    key: string,
+  ): Promise<Entry<Result> | undefined> {
+    const cacheKey = this.buildCacheKey(namespace, key);
+    const value = this.state.get(cacheKey);
     if (!value) {
       return Promise.resolve(undefined);
     }
     if (value.expires <= Date.now()) {
-      await this.remove(key);
+      await this.remove(namespace, key);
     }
 
     if (this.capacity) {
-      this.setMostRecentlyUsed(key, value);
+      this.setMostRecentlyUsed(cacheKey, value);
     }
 
     return Promise.resolve(value.entry);
   }
 
-  public async set<Result>(key: string, entry: Entry<Result>): Promise<void> {
+  public async set<Result>(
+    namespace: string,
+    key: string,
+    entry: Entry<Result>,
+  ): Promise<void> {
+    const cacheKey = this.buildCacheKey(namespace, key);
+
     if (this.capacity) {
-      this.setMostRecentlyUsed(key, {
+      this.setMostRecentlyUsed(cacheKey, {
         expires: entry.staleUntil,
         entry,
       });
     } else {
-      this.state.set(key, {
+      this.state.set(cacheKey, {
         expires: entry.staleUntil,
         entry,
       });
@@ -67,25 +81,33 @@ export class MemoryStore implements Store {
     return Promise.resolve();
   }
 
-  public async remove(keys: string | string[]): Promise<void> {
+  public async remove(namespace: string, keys: string | string[]): Promise<void> {
     const cacheKeys = Array.isArray(keys) ? keys : [keys];
 
     for (const key of cacheKeys) {
-      this.state.delete(key);
+      this.state.delete(this.buildCacheKey(namespace, key));
     }
     return Promise.resolve();
   }
 
-  public async removeByPrefix(prefix: string): Promise<void> {
+  public async removeByPrefix(
+    namespace: string,
+    prefix: string,
+  ): Promise<void> {
+    const cacheKeyPrefix = this.buildCacheKey(namespace, prefix);
+
     for (const key of this.state.keys()) {
-      if (key.startsWith(prefix)) {
+      if (key.startsWith(cacheKeyPrefix)) {
         this.state.delete(key);
       }
     }
   }
 
-  public async removeByPattern(pattern: string): Promise<void> {
-    const regex = this.globToRegex(pattern);
+  public async removeByPattern(
+    namespace: string,
+    pattern: string,
+  ): Promise<void> {
+    const regex = this.globToRegex(this.buildCacheKey(namespace, pattern));
 
     for (const key of this.state.keys()) {
       if (regex.test(key)) {

--- a/packages/postgrest-server/src/stores/redis.ts
+++ b/packages/postgrest-server/src/stores/redis.ts
@@ -1,14 +1,20 @@
 import type { Entry } from './entry';
 import type { Store } from './interface';
-import type { Redis } from 'ioredis';
+import type { Cluster, Redis } from 'ioredis';
+
+// Keep deletion batches bounded so a single pipeline does not become too large.
+// This also keeps Redis Cluster pipeline validation and Lua-less command payloads cheap.
+const REMOVE_BATCH_SIZE = 500;
+
+export type RedisClient = Redis | Cluster;
 
 export type RedisStoreConfig = {
-  redis: Redis;
+  redis: RedisClient;
   prefix?: string;
 };
 
 export class RedisStore implements Store {
-  private readonly redis: Redis;
+  private readonly redis: RedisClient;
   public readonly name = 'redis';
   private readonly prefix: string;
 
@@ -17,70 +23,202 @@ export class RedisStore implements Store {
     this.prefix = config.prefix || 'sbch';
   }
 
-  private buildCacheKey(key: string): string {
-    return [this.prefix, key].join('::');
+  private buildCacheKey(namespace: string, key: string): string {
+    // The `{namespace}` part is a Redis Cluster hash tag. Redis only hashes the
+    // text inside `{...}`, so every value key and index key for the same table
+    // namespace lands in the same cluster slot.
+    return [this.prefix, `{${namespace}}`, key].join('::');
   }
 
-  public async get<Result>(key: string): Promise<Entry<Result> | undefined> {
-    const res = await this.redis.get(this.buildCacheKey(key));
+  private buildIndexKey(namespace: string): string {
+    // This sorted set is the namespace-local catalog of cached query keys.
+    // Members are logical cache keys, scores are staleUntil timestamps.
+    // Keeping this in the same `{namespace}` slot lets us avoid Redis SCAN.
+    return [this.prefix, `{${namespace}}`, '__keys'].join('::');
+  }
+
+  public async get<Result>(
+    namespace: string,
+    key: string,
+  ): Promise<Entry<Result> | undefined> {
+    // Reads go directly to the value key. Expiration is handled by Redis via
+    // PXAT, so a missing value is a cache miss.
+    const res = await this.redis.get(this.buildCacheKey(namespace, key));
     if (!res) return;
 
     return JSON.parse(res) as Entry<Result>;
   }
 
-  public async set<Result>(key: string, entry: Entry<Result>): Promise<void> {
-    await this.redis.set(
-      this.buildCacheKey(key),
+  public async set<Result>(
+    namespace: string,
+    key: string,
+    entry: Entry<Result>,
+  ): Promise<void> {
+    const indexKey = this.buildIndexKey(namespace);
+    const pipeline = this.redis.pipeline();
+
+    // Store the actual cache payload with the same absolute expiration used by
+    // the SWR entry. Redis removes this key automatically after staleUntil.
+    pipeline.set(
+      this.buildCacheKey(namespace, key),
       JSON.stringify(entry),
       'PXAT',
       entry.staleUntil,
     );
+
+    // Add/update the logical cache key in the namespace index. The score mirrors
+    // the value key's expiry so we can prune stale index entries cheaply when we
+    // later read the index for invalidation.
+    pipeline.zadd(indexKey, entry.staleUntil, key);
+
+    await this.execPipeline(pipeline);
+
+    // Best-effort index cleanup: do not make writes wait for pruning. The value
+    // key is already stored correctly, and stale index members are also pruned
+    // before invalidation reads the index. Catch errors to avoid unhandled
+    // promise rejections from this fire-and-forget maintenance command.
+    void this.redis
+      .zremrangebyscore(indexKey, '-inf', Date.now())
+      .catch(() => undefined);
   }
 
-  public async remove(keys: string | string[]): Promise<void> {
-    const cacheKeys = (Array.isArray(keys) ? keys : [keys]).map((key) =>
-      this.buildCacheKey(key).toString(),
-    );
-    this.redis.del(...cacheKeys);
+  public async remove(namespace: string, keys: string | string[]): Promise<void> {
+    // Explicit removal must delete both value keys and their namespace-index
+    // members, otherwise future prefix/pattern invalidation would see stale keys.
+    await this.removeIndexedKeys(namespace, Array.isArray(keys) ? keys : [keys]);
   }
 
-  public async removeByPrefix(prefix: string): Promise<void> {
-    const pattern = `${prefix}*`;
+  public async removeByPrefix(
+    namespace: string,
+    prefix: string,
+  ): Promise<void> {
+    // Prefix invalidation works against the namespace index instead of Redis
+    // keyspace SCAN. The index only contains keys for this table namespace.
+    await this.removeIndexedKeysWhere(namespace, (key) => key.startsWith(prefix));
+  }
+
+  public async removeByPattern(
+    namespace: string,
+    pattern: string,
+  ): Promise<void> {
+    // Filter invalidation is still pattern based because we do not know all user
+    // filter dimensions ahead of time. We only pattern-match within one table's
+    // indexed keys, avoiding a Redis Cluster-wide scan.
+    const regex = this.globToRegex(pattern);
+
+    await this.removeIndexedKeysWhere(namespace, (key) => regex.test(key));
+  }
+
+  private async removeIndexedKeysWhere(
+    namespace: string,
+    predicate: (key: string) => boolean,
+  ): Promise<void> {
+    const indexKey = this.buildIndexKey(namespace);
     let cursor = '0';
 
-    do {
-      const [nextCursor, keys] = await this.redis.scan(
-        cursor,
-        'MATCH',
-        pattern,
-        'COUNT',
-        100,
-      );
-      cursor = nextCursor;
+    // Remove expired index members before reading the index. This keeps the
+    // namespace catalog bounded even when cache entries expire naturally.
+    await this.redis.zremrangebyscore(indexKey, '-inf', Date.now());
 
-      if (keys.length > 0) {
-        await this.redis.del(...keys);
+    do {
+      // ZSCAN pages through the namespace index so invalidating a large table
+      // does not load every indexed key into application memory at once. The
+      // response is a flat [member, score, member, score, ...] array.
+      const [nextCursor, membersAndScores] = await this.redis.zscan(
+        indexKey,
+        cursor,
+        'COUNT',
+        REMOVE_BATCH_SIZE,
+      );
+      const keys: string[] = [];
+
+      for (let i = 0; i < membersAndScores.length; i += 2) {
+        const key = membersAndScores[i];
+
+        if (predicate(key)) {
+          keys.push(key);
+        }
       }
+
+      // Delete each matching page before continuing. This bounds both memory and
+      // Redis command size; duplicate ZSCAN results are harmless because DEL and
+      // ZREM are idempotent for already-removed keys.
+      await this.removeIndexedKeys(namespace, keys);
+      cursor = nextCursor;
     } while (cursor !== '0');
   }
 
-  public async removeByPattern(pattern: string): Promise<void> {
-    const fullPattern = this.buildCacheKey(pattern);
-    let cursor = '0';
+  private async removeIndexedKeys(
+    namespace: string,
+    keys: string[],
+  ): Promise<void> {
+    if (keys.length === 0) return;
 
-    do {
-      const [nextCursor, keys] = await this.redis.scan(
-        cursor,
-        'MATCH',
-        fullPattern,
-        'COUNT',
-        100,
-      );
-      cursor = nextCursor;
+    const indexKey = this.buildIndexKey(namespace);
 
-      if (keys.length > 0) {
-        await this.redis.del(...keys);
+    for (let i = 0; i < keys.length; i += REMOVE_BATCH_SIZE) {
+      const batch = keys.slice(i, i + REMOVE_BATCH_SIZE);
+      const pipeline = this.redis.pipeline();
+
+      // Delete the actual Redis value keys for this batch.
+      pipeline.del(...batch.map((key) => this.buildCacheKey(namespace, key)));
+
+      // Remove the same logical keys from the namespace index so future
+      // invalidation calls do not process already-deleted values.
+      pipeline.zrem(indexKey, ...batch);
+
+      await this.execPipeline(pipeline);
+    }
+  }
+
+  private async execPipeline(
+    pipeline: ReturnType<RedisClient['pipeline']>,
+  ): Promise<void> {
+    const results = await pipeline.exec();
+
+    // ioredis pipelines report per-command errors in the result array instead
+    // of throwing for every command failure, so surface the first command error.
+    const error = results?.find(([error]) => error)?.[0];
+
+    if (error) throw error;
+  }
+
+  /**
+   * Convert a Redis-style glob pattern to a JavaScript RegExp.
+   * Supports: * (any chars), ? (single char), \* \? \[ \] (literals)
+   */
+  private globToRegex(pattern: string): RegExp {
+    let regex = '^';
+    let i = 0;
+
+    while (i < pattern.length) {
+      const char = pattern[i];
+
+      if (char === '\\' && i + 1 < pattern.length) {
+        // Preserve escaped glob characters as literals.
+        const next = pattern[i + 1];
+        regex += '\\' + next;
+        i += 2;
+      } else if (char === '*') {
+        // Redis glob '*' maps to any number of characters.
+        regex += '.*';
+        i++;
+      } else if (char === '?') {
+        // Redis glob '?' maps to exactly one character.
+        regex += '.';
+        i++;
+      } else if (/[.+^${}()|[\]\\]/.test(char)) {
+        // Escape RegExp metacharacters that are not Redis glob operators.
+        regex += '\\' + char;
+        i++;
+      } else {
+        // Ordinary characters match themselves.
+        regex += char;
+        i++;
       }
-    } while (cursor !== '0');
+    }
+
+    regex += '$';
+    return new RegExp(regex);
   }
 }

--- a/packages/postgrest-server/src/stores/redis.ts
+++ b/packages/postgrest-server/src/stores/redis.ts
@@ -82,10 +82,16 @@ export class RedisStore implements Store {
       .catch(() => undefined);
   }
 
-  public async remove(namespace: string, keys: string | string[]): Promise<void> {
+  public async remove(
+    namespace: string,
+    keys: string | string[],
+  ): Promise<void> {
     // Explicit removal must delete both value keys and their namespace-index
     // members, otherwise future prefix/pattern invalidation would see stale keys.
-    await this.removeIndexedKeys(namespace, Array.isArray(keys) ? keys : [keys]);
+    await this.removeIndexedKeys(
+      namespace,
+      Array.isArray(keys) ? keys : [keys],
+    );
   }
 
   public async removeByPrefix(
@@ -94,7 +100,9 @@ export class RedisStore implements Store {
   ): Promise<void> {
     // Prefix invalidation works against the namespace index instead of Redis
     // keyspace SCAN. The index only contains keys for this table namespace.
-    await this.removeIndexedKeysWhere(namespace, (key) => key.startsWith(prefix));
+    await this.removeIndexedKeysWhere(namespace, (key) =>
+      key.startsWith(prefix),
+    );
   }
 
   public async removeByPattern(

--- a/packages/postgrest-server/src/swr-cache.ts
+++ b/packages/postgrest-server/src/swr-cache.ts
@@ -27,17 +27,17 @@ export class SwrCache {
   }
 
   /**
-   * Invalidate all keys that start with the given prefix
+   * Invalidate all keys in the namespace that start with the given prefix
    **/
-  async removeByPrefix(prefix: string) {
-    return this.store.removeByPrefix(prefix);
+  async removeByPrefix(namespace: string, prefix: string) {
+    return this.store.removeByPrefix(namespace, prefix);
   }
 
   /**
-   * Invalidate all keys matching the given glob pattern
+   * Invalidate all keys in the namespace matching the given glob pattern
    **/
-  async removeByPattern(pattern: string) {
-    return this.store.removeByPattern(pattern);
+  async removeByPattern(namespace: string, pattern: string) {
+    return this.store.removeByPattern(namespace, pattern);
   }
 
   /**
@@ -45,15 +45,19 @@ export class SwrCache {
    *
    * The response will be `undefined` for cache misses or `null` when the key was not found in the origin
    */
-  public async get<Result>(key: string): Promise<Value<Result> | undefined> {
-    const res = await this._get<Result>(key);
+  public async get<Result>(
+    namespace: string,
+    key: string,
+  ): Promise<Value<Result> | undefined> {
+    const res = await this._get<Result>(namespace, key);
     return res.value;
   }
 
   private async _get<Result>(
+    namespace: string,
     key: string,
   ): Promise<{ value: Value<Result> | undefined; revalidate?: boolean }> {
-    const res = await this.store.get<Result>(key);
+    const res = await this.store.get<Result>(namespace, key);
 
     const now = Date.now();
     if (!res) {
@@ -61,7 +65,7 @@ export class SwrCache {
     }
 
     if (now >= res.staleUntil) {
-      this.ctx.waitUntil(this.remove(key));
+      this.ctx.waitUntil(this.remove(namespace, key));
       return { value: undefined };
     }
     if (now >= res.freshUntil) {
@@ -75,6 +79,7 @@ export class SwrCache {
    * Set the value
    */
   public async set<Result>(
+    namespace: string,
     key: string,
     value: Value<Result>,
     opts?: {
@@ -83,7 +88,7 @@ export class SwrCache {
     },
   ): Promise<void> {
     const now = Date.now();
-    return this.store.set(key, {
+    return this.store.set(namespace, key, {
       value,
       freshUntil: now + (opts?.fresh ?? this.fresh),
       staleUntil: now + (opts?.stale ?? this.stale),
@@ -93,11 +98,12 @@ export class SwrCache {
   /**
    * Removes the key from the cache.
    */
-  public async remove(key: string): Promise<void> {
-    return this.store.remove(key);
+  public async remove(namespace: string, key: string): Promise<void> {
+    return this.store.remove(namespace, key);
   }
 
   public async swr<Result>(
+    namespace: string,
     key: string,
     loadFromOrigin: (key: string) => Promise<Value<Result>>,
     opts?: {
@@ -105,7 +111,7 @@ export class SwrCache {
       stale: number;
     },
   ): Promise<Value<Result>> {
-    const res = await this._get<Result>(key);
+    const res = await this._get<Result>(namespace, key);
 
     const { value, revalidate } = res;
 
@@ -114,7 +120,7 @@ export class SwrCache {
         this.ctx.waitUntil(
           loadFromOrigin(key).then((res) => {
             if (!isEmpty(res)) {
-              this.set(key, res, opts);
+              this.set(namespace, key, res, opts);
             }
           }),
         );
@@ -125,7 +131,7 @@ export class SwrCache {
 
     const loadedValue = await loadFromOrigin(key);
     if (!isEmpty(loadedValue)) {
-      this.ctx.waitUntil(this.set(key, loadedValue));
+      this.ctx.waitUntil(this.set(namespace, key, loadedValue));
     }
     return loadedValue;
   }

--- a/packages/postgrest-server/src/tiered-store.ts
+++ b/packages/postgrest-server/src/tiered-store.ts
@@ -35,13 +35,16 @@ export class TieredStore implements Store {
    *
    * The response will be `undefined` for cache misses or `null` when the key was not found in the origin
    */
-  public async get<Result>(key: string): Promise<Entry<Result> | undefined> {
+  public async get<Result>(
+    namespace: string,
+    key: string,
+  ): Promise<Entry<Result> | undefined> {
     if (this.tiers.length === 0) {
       return;
     }
 
     for (let i = 0; i < this.tiers.length; i++) {
-      const res = await this.tiers[i].get<Result>(key);
+      const res = await this.tiers[i].get<Result>(namespace, key);
 
       if (!res) {
         return;
@@ -50,7 +53,9 @@ export class TieredStore implements Store {
       // Fill all lower caches
       this.ctx.waitUntil(
         Promise.all(
-          this.tiers.filter((_, j) => j < i).map((t) => () => t.set(key, res)),
+          this.tiers
+            .filter((_, j) => j < i)
+            .map((t) => t.set(namespace, key, res)),
         ),
       );
 
@@ -61,28 +66,45 @@ export class TieredStore implements Store {
   /**
    * Sets the value for the given key.
    */
-  public async set<Result>(key: string, value: Entry<Result>): Promise<void> {
-    await Promise.all(this.tiers.map((t) => t.set(key, value)));
+  public async set<Result>(
+    namespace: string,
+    key: string,
+    value: Entry<Result>,
+  ): Promise<void> {
+    await Promise.all(this.tiers.map((t) => t.set(namespace, key, value)));
   }
 
   /**
    * Removes the key from the cache.
    */
-  public async remove(key: string): Promise<void> {
-    await Promise.all(this.tiers.map((t) => t.remove(key)));
+  public async remove(
+    namespace: string,
+    key: string | string[],
+  ): Promise<void> {
+    await Promise.all(this.tiers.map((t) => t.remove(namespace, key)));
   }
 
   /**
    * Removes all keys with the given prefix.
    */
-  public async removeByPrefix(prefix: string): Promise<void> {
-    await Promise.all(this.tiers.map((t) => t.removeByPrefix(prefix)));
+  public async removeByPrefix(
+    namespace: string,
+    prefix: string,
+  ): Promise<void> {
+    await Promise.all(
+      this.tiers.map((t) => t.removeByPrefix(namespace, prefix)),
+    );
   }
 
   /**
    * Removes all keys matching the given glob pattern.
    */
-  public async removeByPattern(pattern: string): Promise<void> {
-    await Promise.all(this.tiers.map((t) => t.removeByPattern(pattern)));
+  public async removeByPattern(
+    namespace: string,
+    pattern: string,
+  ): Promise<void> {
+    await Promise.all(
+      this.tiers.map((t) => t.removeByPattern(namespace, pattern)),
+    );
   }
 }

--- a/packages/postgrest-server/tests/key.test.ts
+++ b/packages/postgrest-server/tests/key.test.ts
@@ -1,9 +1,9 @@
-import { buildFilterPattern, buildTablePrefix } from '../src/key';
+import { buildFilterPattern, getTablePrefix } from '../src/key';
 import { describe, expect, test } from 'vitest';
 
-describe('buildTablePrefix', () => {
+describe('getTablePrefix', () => {
   test('should join schema and table with separator', () => {
-    expect(buildTablePrefix('public', 'posts')).toBe('public$posts');
+    expect(getTablePrefix('public', 'posts')).toBe('public$posts');
   });
 });
 

--- a/packages/postgrest-server/tests/stores/memory.test.ts
+++ b/packages/postgrest-server/tests/stores/memory.test.ts
@@ -92,9 +92,21 @@ describe('MemoryStore', () => {
       freshUntil: Date.now() + 1000000,
       staleUntil: Date.now() + 100000000,
     };
-    await memoryStore.set(namespace, 'public$posts$select=*&user_id=eq.5', entry);
-    await memoryStore.set(namespace, 'public$posts$select=*&user_id=eq.10', entry);
-    await memoryStore.set(namespace, 'public$posts$select=*&status=eq.active', entry);
+    await memoryStore.set(
+      namespace,
+      'public$posts$select=*&user_id=eq.5',
+      entry,
+    );
+    await memoryStore.set(
+      namespace,
+      'public$posts$select=*&user_id=eq.10',
+      entry,
+    );
+    await memoryStore.set(
+      namespace,
+      'public$posts$select=*&status=eq.active',
+      entry,
+    );
 
     // Pattern: match keys containing user_id=eq.5
     await memoryStore.removeByPattern(namespace, 'public$posts$*user_id=eq.5*');
@@ -106,7 +118,10 @@ describe('MemoryStore', () => {
       await memoryStore.get(namespace, 'public$posts$select=*&user_id=eq.10'),
     ).toBeDefined();
     expect(
-      await memoryStore.get(namespace, 'public$posts$select=*&status=eq.active'),
+      await memoryStore.get(
+        namespace,
+        'public$posts$select=*&status=eq.active',
+      ),
     ).toBeDefined();
   });
 
@@ -122,7 +137,11 @@ describe('MemoryStore', () => {
       'public$posts$select=*&name=eq.%2Atest%2A',
       entry,
     );
-    await memoryStore.set(namespace, 'public$posts$select=*&name=eq.other', entry);
+    await memoryStore.set(
+      namespace,
+      'public$posts$select=*&name=eq.other',
+      entry,
+    );
 
     // Pattern with escaped * to match literal %2A (URL-encoded *)
     await memoryStore.removeByPattern(
@@ -131,7 +150,10 @@ describe('MemoryStore', () => {
     );
 
     expect(
-      await memoryStore.get(namespace, 'public$posts$select=*&name=eq.%2Atest%2A'),
+      await memoryStore.get(
+        namespace,
+        'public$posts$select=*&name=eq.%2Atest%2A',
+      ),
     ).toBeUndefined();
     expect(
       await memoryStore.get(namespace, 'public$posts$select=*&name=eq.other'),

--- a/packages/postgrest-server/tests/stores/memory.test.ts
+++ b/packages/postgrest-server/tests/stores/memory.test.ts
@@ -10,6 +10,7 @@ const createCacheValue = (value: string): Value<string> => ({
 });
 
 describe('MemoryStore', () => {
+  const namespace = 'public$posts';
   let memoryStore: MemoryStore;
 
   beforeEach(() => {
@@ -23,22 +24,22 @@ describe('MemoryStore', () => {
       freshUntil: Date.now() + 1000000,
       staleUntil: Date.now() + 100000000,
     };
-    await memoryStore.set(key, entry);
-    expect(await memoryStore.get(key)).toEqual(entry);
+    await memoryStore.set(namespace, key, entry);
+    expect(await memoryStore.get(namespace, key)).toEqual(entry);
   });
 
   test('should return undefined if key does not exist in cache', async () => {
-    expect(await memoryStore.get('doesnotexist')).toEqual(undefined);
+    expect(await memoryStore.get(namespace, 'doesnotexist')).toEqual(undefined);
   });
 
   test('should remove value from cache', async () => {
-    memoryStore.set('key', {
+    memoryStore.set(namespace, 'key', {
       value: createCacheValue('name'),
       freshUntil: Date.now() + 10000000,
       staleUntil: Date.now() + 12312412512515,
     });
-    memoryStore.remove('key');
-    expect(await memoryStore.get('key')).toEqual(undefined);
+    memoryStore.remove(namespace, 'key');
+    expect(await memoryStore.get(namespace, 'key')).toEqual(undefined);
   });
 
   test('should respect capacity', async () => {
@@ -56,10 +57,10 @@ describe('MemoryStore', () => {
       freshUntil: Date.now() + 1000000,
       staleUntil: Date.now() + 100000000,
     };
-    await memoryStore.set('key1', entry1);
-    await memoryStore.set('key2', entry2);
-    expect(await memoryStore.get('key1')).toBeUndefined();
-    expect(await memoryStore.get('key2')).toBeDefined();
+    await memoryStore.set(namespace, 'key1', entry1);
+    await memoryStore.set(namespace, 'key2', entry2);
+    expect(await memoryStore.get(namespace, 'key1')).toBeUndefined();
+    expect(await memoryStore.get(namespace, 'key2')).toBeDefined();
   });
 
   test('should remove keys by prefix', async () => {
@@ -68,15 +69,21 @@ describe('MemoryStore', () => {
       freshUntil: Date.now() + 1000000,
       staleUntil: Date.now() + 100000000,
     };
-    await memoryStore.set('public$posts$select=*', entry);
-    await memoryStore.set('public$posts$user_id=eq.5', entry);
-    await memoryStore.set('public$comments$select=*', entry);
+    await memoryStore.set(namespace, 'public$posts$select=*', entry);
+    await memoryStore.set(namespace, 'public$posts$user_id=eq.5', entry);
+    await memoryStore.set('public$comments', 'public$comments$select=*', entry);
 
-    await memoryStore.removeByPrefix('public$posts$');
+    await memoryStore.removeByPrefix(namespace, 'public$posts$');
 
-    expect(await memoryStore.get('public$posts$select=*')).toBeUndefined();
-    expect(await memoryStore.get('public$posts$user_id=eq.5')).toBeUndefined();
-    expect(await memoryStore.get('public$comments$select=*')).toBeDefined();
+    expect(
+      await memoryStore.get(namespace, 'public$posts$select=*'),
+    ).toBeUndefined();
+    expect(
+      await memoryStore.get(namespace, 'public$posts$user_id=eq.5'),
+    ).toBeUndefined();
+    expect(
+      await memoryStore.get('public$comments', 'public$comments$select=*'),
+    ).toBeDefined();
   });
 
   test('should remove keys by glob pattern', async () => {
@@ -85,21 +92,21 @@ describe('MemoryStore', () => {
       freshUntil: Date.now() + 1000000,
       staleUntil: Date.now() + 100000000,
     };
-    await memoryStore.set('public$posts$select=*&user_id=eq.5', entry);
-    await memoryStore.set('public$posts$select=*&user_id=eq.10', entry);
-    await memoryStore.set('public$posts$select=*&status=eq.active', entry);
+    await memoryStore.set(namespace, 'public$posts$select=*&user_id=eq.5', entry);
+    await memoryStore.set(namespace, 'public$posts$select=*&user_id=eq.10', entry);
+    await memoryStore.set(namespace, 'public$posts$select=*&status=eq.active', entry);
 
     // Pattern: match keys containing user_id=eq.5
-    await memoryStore.removeByPattern('public$posts$*user_id=eq.5*');
+    await memoryStore.removeByPattern(namespace, 'public$posts$*user_id=eq.5*');
 
     expect(
-      await memoryStore.get('public$posts$select=*&user_id=eq.5'),
+      await memoryStore.get(namespace, 'public$posts$select=*&user_id=eq.5'),
     ).toBeUndefined();
     expect(
-      await memoryStore.get('public$posts$select=*&user_id=eq.10'),
+      await memoryStore.get(namespace, 'public$posts$select=*&user_id=eq.10'),
     ).toBeDefined();
     expect(
-      await memoryStore.get('public$posts$select=*&status=eq.active'),
+      await memoryStore.get(namespace, 'public$posts$select=*&status=eq.active'),
     ).toBeDefined();
   });
 
@@ -110,17 +117,24 @@ describe('MemoryStore', () => {
       staleUntil: Date.now() + 100000000,
     };
     // Key with literal * in the value (URL-encoded as %2A)
-    await memoryStore.set('public$posts$select=*&name=eq.%2Atest%2A', entry);
-    await memoryStore.set('public$posts$select=*&name=eq.other', entry);
+    await memoryStore.set(
+      namespace,
+      'public$posts$select=*&name=eq.%2Atest%2A',
+      entry,
+    );
+    await memoryStore.set(namespace, 'public$posts$select=*&name=eq.other', entry);
 
     // Pattern with escaped * to match literal %2A (URL-encoded *)
-    await memoryStore.removeByPattern('public$posts$*name=eq.%2Atest%2A*');
+    await memoryStore.removeByPattern(
+      namespace,
+      'public$posts$*name=eq.%2Atest%2A*',
+    );
 
     expect(
-      await memoryStore.get('public$posts$select=*&name=eq.%2Atest%2A'),
+      await memoryStore.get(namespace, 'public$posts$select=*&name=eq.%2Atest%2A'),
     ).toBeUndefined();
     expect(
-      await memoryStore.get('public$posts$select=*&name=eq.other'),
+      await memoryStore.get(namespace, 'public$posts$select=*&name=eq.other'),
     ).toBeDefined();
   });
 
@@ -130,15 +144,21 @@ describe('MemoryStore', () => {
       freshUntil: Date.now() + 1000000,
       staleUntil: Date.now() + 100000000,
     };
-    await memoryStore.set('public$posts$user_id=eq.1', entry);
-    await memoryStore.set('public$posts$user_id=eq.2', entry);
-    await memoryStore.set('public$posts$user_id=eq.10', entry);
+    await memoryStore.set(namespace, 'public$posts$user_id=eq.1', entry);
+    await memoryStore.set(namespace, 'public$posts$user_id=eq.2', entry);
+    await memoryStore.set(namespace, 'public$posts$user_id=eq.10', entry);
 
     // Pattern with ? matches single char
-    await memoryStore.removeByPattern('public$posts$user_id=eq.?');
+    await memoryStore.removeByPattern(namespace, 'public$posts$user_id=eq.?');
 
-    expect(await memoryStore.get('public$posts$user_id=eq.1')).toBeUndefined();
-    expect(await memoryStore.get('public$posts$user_id=eq.2')).toBeUndefined();
-    expect(await memoryStore.get('public$posts$user_id=eq.10')).toBeDefined();
+    expect(
+      await memoryStore.get(namespace, 'public$posts$user_id=eq.1'),
+    ).toBeUndefined();
+    expect(
+      await memoryStore.get(namespace, 'public$posts$user_id=eq.2'),
+    ).toBeUndefined();
+    expect(
+      await memoryStore.get(namespace, 'public$posts$user_id=eq.10'),
+    ).toBeDefined();
   });
 });

--- a/packages/postgrest-server/tests/stores/redis.test.ts
+++ b/packages/postgrest-server/tests/stores/redis.test.ts
@@ -94,7 +94,10 @@ const startRedisCluster = async (): Promise<StartedRedisCluster> => {
       };
 
       return [
-        [`${container.getIpAddress(network.getName())}:${REDIS_PORT}`, mappedNode],
+        [
+          `${container.getIpAddress(network.getName())}:${REDIS_PORT}`,
+          mappedNode,
+        ],
         [`redis-node-${index}:${REDIS_PORT}`, mappedNode],
       ];
     }),
@@ -143,7 +146,10 @@ const flushRedisCluster = async (cluster: Cluster): Promise<void> => {
   await Promise.all(cluster.nodes('master').map((node) => node.flushall()));
 };
 
-const scanClient = async (client: Redis, pattern: string): Promise<string[]> => {
+const scanClient = async (
+  client: Redis,
+  pattern: string,
+): Promise<string[]> => {
   const keys: string[] = [];
   let cursor = '0';
 
@@ -162,7 +168,10 @@ const scanClient = async (client: Redis, pattern: string): Promise<string[]> => 
   return keys;
 };
 
-const scanCluster = async (cluster: Cluster, pattern: string): Promise<string[]> => {
+const scanCluster = async (
+  cluster: Cluster,
+  pattern: string,
+): Promise<string[]> => {
   const batches = await Promise.all(
     cluster.nodes('master').map((node) => scanClient(node, pattern)),
   );
@@ -256,13 +265,22 @@ describe('RedisStore', () => {
     );
 
     expect(
-      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.5'),
+      await redisStore.get(
+        postsNamespace,
+        'public$posts$select=*&user_id=eq.5',
+      ),
     ).toBeUndefined();
     expect(
-      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.10'),
+      await redisStore.get(
+        postsNamespace,
+        'public$posts$select=*&user_id=eq.10',
+      ),
     ).toBeDefined();
     expect(
-      await redisStore.get(postsNamespace, 'public$posts$select=*&status=eq.active'),
+      await redisStore.get(
+        postsNamespace,
+        'public$posts$select=*&status=eq.active',
+      ),
     ).toBeDefined();
   });
 });
@@ -302,9 +320,9 @@ describe('RedisStore with Redis Cluster', () => {
     expect(
       await scanCluster(cluster, 'test::{public$posts}::public$posts$select=*'),
     ).toEqual(['test::{public$posts}::public$posts$select=*']);
-    expect(await redisStore.get(postsNamespace, 'public$posts$select=*')).toEqual(
-      entry,
-    );
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*'),
+    ).toEqual(entry);
   });
 
   test('should remove multiple values in a namespace', async () => {
@@ -370,13 +388,22 @@ describe('RedisStore with Redis Cluster', () => {
     );
 
     expect(
-      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.5'),
+      await redisStore.get(
+        postsNamespace,
+        'public$posts$select=*&user_id=eq.5',
+      ),
     ).toBeUndefined();
     expect(
-      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.10'),
+      await redisStore.get(
+        postsNamespace,
+        'public$posts$select=*&user_id=eq.10',
+      ),
     ).toBeDefined();
     expect(
-      await redisStore.get(postsNamespace, 'public$posts$select=*&status=eq.active'),
+      await redisStore.get(
+        postsNamespace,
+        'public$posts$select=*&status=eq.active',
+      ),
     ).toBeDefined();
   });
 });

--- a/packages/postgrest-server/tests/stores/redis.test.ts
+++ b/packages/postgrest-server/tests/stores/redis.test.ts
@@ -1,6 +1,13 @@
 import { RedisStore, Value } from '../../src/stores';
 import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis';
-import { Redis } from 'ioredis';
+import { Cluster, Redis } from 'ioredis';
+import {
+  GenericContainer,
+  Network,
+  StartedNetwork,
+  type StartedTestContainer,
+  Wait,
+} from 'testcontainers';
 import {
   afterAll,
   beforeAll,
@@ -10,6 +17,9 @@ import {
   test,
 } from 'vitest';
 
+const REDIS_IMAGE = 'redis:7-alpine';
+const REDIS_PORT = 6379;
+
 const createCacheValue = (value: string): Value<string> => ({
   data: value,
   error: null,
@@ -18,13 +28,157 @@ const createCacheValue = (value: string): Value<string> => ({
   statusText: 'OK',
 });
 
+const createEntry = (value: string) => ({
+  value: createCacheValue(value),
+  freshUntil: Date.now() + 1000000,
+  staleUntil: Date.now() + 100000000,
+});
+
+type StartedRedisCluster = {
+  cluster: Cluster;
+  containers: StartedTestContainer[];
+  network: StartedNetwork;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const startRedisCluster = async (): Promise<StartedRedisCluster> => {
+  const network = await new Network().start();
+  const containers = await Promise.all(
+    Array.from({ length: 3 }, (_, index) =>
+      new GenericContainer(REDIS_IMAGE)
+        .withNetwork(network)
+        .withNetworkAliases(`redis-node-${index}`)
+        .withExposedPorts(REDIS_PORT)
+        .withCommand([
+          'redis-server',
+          '--port',
+          `${REDIS_PORT}`,
+          '--cluster-enabled',
+          'yes',
+          '--cluster-config-file',
+          `nodes-${index}.conf`,
+          '--cluster-node-timeout',
+          '5000',
+          '--appendonly',
+          'no',
+          '--protected-mode',
+          'no',
+        ])
+        .withWaitStrategy(Wait.forListeningPorts())
+        .withStartupTimeout(60000)
+        .start(),
+    ),
+  );
+
+  const createResult = await containers[0].exec([
+    'redis-cli',
+    '--cluster',
+    'create',
+    ...containers.map((_, index) => `redis-node-${index}:${REDIS_PORT}`),
+    '--cluster-replicas',
+    '0',
+    '--cluster-yes',
+  ]);
+
+  if (createResult.exitCode !== 0) {
+    throw new Error(createResult.output);
+  }
+
+  const host = containers[0].getHost();
+  const natMap = Object.fromEntries(
+    containers.flatMap((container, index) => {
+      const mappedNode = {
+        host: container.getHost(),
+        port: container.getMappedPort(REDIS_PORT),
+      };
+
+      return [
+        [`${container.getIpAddress(network.getName())}:${REDIS_PORT}`, mappedNode],
+        [`redis-node-${index}:${REDIS_PORT}`, mappedNode],
+      ];
+    }),
+  );
+
+  const cluster = new Cluster(
+    [{ host, port: containers[0].getMappedPort(REDIS_PORT) }],
+    {
+      natMap,
+      slotsRefreshTimeout: 2000,
+      redisOptions: {
+        maxRetriesPerRequest: 1,
+      },
+    },
+  );
+
+  await waitForCluster(cluster);
+
+  return { cluster, containers, network };
+};
+
+const waitForCluster = async (cluster: Cluster): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      await cluster.set('cluster-health-check', 'ok');
+      await cluster.del('cluster-health-check');
+      return;
+    } catch (error) {
+      if (attempt === 19) throw error;
+      await sleep(250);
+    }
+  }
+};
+
+const stopRedisCluster = async ({
+  cluster,
+  containers,
+  network,
+}: StartedRedisCluster): Promise<void> => {
+  await cluster.quit();
+  await Promise.all(containers.map((container) => container.stop()));
+  await network.stop();
+};
+
+const flushRedisCluster = async (cluster: Cluster): Promise<void> => {
+  await Promise.all(cluster.nodes('master').map((node) => node.flushall()));
+};
+
+const scanClient = async (client: Redis, pattern: string): Promise<string[]> => {
+  const keys: string[] = [];
+  let cursor = '0';
+
+  do {
+    const [nextCursor, batch] = await client.scan(
+      cursor,
+      'MATCH',
+      pattern,
+      'COUNT',
+      100,
+    );
+    keys.push(...batch);
+    cursor = nextCursor;
+  } while (cursor !== '0');
+
+  return keys;
+};
+
+const scanCluster = async (cluster: Cluster, pattern: string): Promise<string[]> => {
+  const batches = await Promise.all(
+    cluster.nodes('master').map((node) => scanClient(node, pattern)),
+  );
+
+  return batches.flat();
+};
+
 describe('RedisStore', () => {
+  const postsNamespace = 'public$posts';
+  const commentsNamespace = 'public$comments';
   let container: StartedRedisContainer;
   let redis: Redis;
   let redisStore: RedisStore;
 
   beforeAll(async () => {
-    container = await new RedisContainer('redis:7-alpine').start();
+    container = await new RedisContainer(REDIS_IMAGE).start();
     redis = new Redis(container.getConnectionUrl());
   }, 60000);
 
@@ -40,69 +194,189 @@ describe('RedisStore', () => {
 
   test('should store value in the cache', async () => {
     const key = 'key';
-    const entry = {
-      value: createCacheValue('name'),
-      freshUntil: Date.now() + 1000000,
-      staleUntil: Date.now() + 100000000,
-    };
-    await redisStore.set(key, entry);
-    expect(await redisStore.get(key)).toEqual(entry);
+    const entry = createEntry('name');
+    await redisStore.set(postsNamespace, key, entry);
+    expect(await redisStore.get(postsNamespace, key)).toEqual(entry);
   });
 
   test('should return undefined if key does not exist in cache', async () => {
-    expect(await redisStore.get('doesnotexist')).toEqual(undefined);
+    expect(await redisStore.get(postsNamespace, 'doesnotexist')).toEqual(
+      undefined,
+    );
   });
 
   test('should remove value from cache', async () => {
-    const entry = {
-      value: createCacheValue('name'),
-      freshUntil: Date.now() + 10000000,
-      staleUntil: Date.now() + 12312412512515,
-    };
-    await redisStore.set('key', entry);
-    await redisStore.remove('key');
-    expect(await redisStore.get('key')).toEqual(undefined);
+    const entry = createEntry('name');
+    await redisStore.set(postsNamespace, 'key', entry);
+    await redisStore.remove(postsNamespace, 'key');
+    expect(await redisStore.get(postsNamespace, 'key')).toEqual(undefined);
   });
 
   test('should remove keys by prefix', async () => {
-    const entry = {
-      value: createCacheValue('name'),
-      freshUntil: Date.now() + 1000000,
-      staleUntil: Date.now() + 100000000,
-    };
-    await redisStore.set('public$posts$select=*', entry);
-    await redisStore.set('public$posts$user_id=eq.5', entry);
-    await redisStore.set('public$comments$select=*', entry);
+    const entry = createEntry('name');
+    await redisStore.set(postsNamespace, 'public$posts$select=*', entry);
+    await redisStore.set(postsNamespace, 'public$posts$user_id=eq.5', entry);
+    await redisStore.set(commentsNamespace, 'public$comments$select=*', entry);
 
-    // Note: removeByPrefix expects the full key pattern including store prefix
-    await redisStore.removeByPrefix('test::public$posts$');
+    await redisStore.removeByPrefix(postsNamespace, 'public$posts');
 
-    expect(await redisStore.get('public$posts$select=*')).toBeUndefined();
-    expect(await redisStore.get('public$posts$user_id=eq.5')).toBeUndefined();
-    expect(await redisStore.get('public$comments$select=*')).toBeDefined();
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*'),
+    ).toBeUndefined();
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$user_id=eq.5'),
+    ).toBeUndefined();
+    expect(
+      await redisStore.get(commentsNamespace, 'public$comments$select=*'),
+    ).toBeDefined();
   });
 
   test('should remove keys by glob pattern', async () => {
-    const entry = {
-      value: createCacheValue('name'),
-      freshUntil: Date.now() + 1000000,
-      staleUntil: Date.now() + 100000000,
-    };
-    await redisStore.set('public$posts$select=*&user_id=eq.5', entry);
-    await redisStore.set('public$posts$select=*&user_id=eq.10', entry);
-    await redisStore.set('public$posts$select=*&status=eq.active', entry);
+    const entry = createEntry('name');
+    await redisStore.set(
+      postsNamespace,
+      'public$posts$select=*&user_id=eq.5',
+      entry,
+    );
+    await redisStore.set(
+      postsNamespace,
+      'public$posts$select=*&user_id=eq.10',
+      entry,
+    );
+    await redisStore.set(
+      postsNamespace,
+      'public$posts$select=*&status=eq.active',
+      entry,
+    );
 
     // Pattern: match keys containing user_id=eq.5
-    await redisStore.removeByPattern('public$posts$*user_id=eq.5*');
+    await redisStore.removeByPattern(
+      postsNamespace,
+      'public$posts$*user_id=eq.5*',
+    );
 
     expect(
-      await redisStore.get('public$posts$select=*&user_id=eq.5'),
+      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.5'),
     ).toBeUndefined();
     expect(
-      await redisStore.get('public$posts$select=*&user_id=eq.10'),
+      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.10'),
     ).toBeDefined();
     expect(
-      await redisStore.get('public$posts$select=*&status=eq.active'),
+      await redisStore.get(postsNamespace, 'public$posts$select=*&status=eq.active'),
+    ).toBeDefined();
+  });
+});
+
+describe('RedisStore with Redis Cluster', () => {
+  const postsNamespace = 'public$posts';
+  const commentsNamespace = 'public$comments';
+  let redisCluster: StartedRedisCluster;
+  let cluster: Cluster;
+  let redisStore: RedisStore;
+
+  beforeAll(async () => {
+    redisCluster = await startRedisCluster();
+    cluster = redisCluster.cluster;
+  }, 120000);
+
+  afterAll(async () => {
+    await stopRedisCluster(redisCluster);
+  });
+
+  beforeEach(async () => {
+    redisStore = new RedisStore({ redis: cluster, prefix: 'test' });
+    await flushRedisCluster(cluster);
+  });
+
+  test('should accept a Cluster client', () => {
+    expect(new RedisStore({ redis: cluster, prefix: 'test' }).name).toBe(
+      'redis',
+    );
+  });
+
+  test('should store cluster cache keys with namespace hash tags', async () => {
+    const entry = createEntry('name');
+
+    await redisStore.set(postsNamespace, 'public$posts$select=*', entry);
+
+    expect(
+      await scanCluster(cluster, 'test::{public$posts}::public$posts$select=*'),
+    ).toEqual(['test::{public$posts}::public$posts$select=*']);
+    expect(await redisStore.get(postsNamespace, 'public$posts$select=*')).toEqual(
+      entry,
+    );
+  });
+
+  test('should remove multiple values in a namespace', async () => {
+    const entry = createEntry('name');
+    await redisStore.set(postsNamespace, 'public$posts$select=*', entry);
+    await redisStore.set(postsNamespace, 'public$posts$user_id=eq.5', entry);
+
+    await expect(
+      redisStore.remove(postsNamespace, [
+        'public$posts$select=*',
+        'public$posts$user_id=eq.5',
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*'),
+    ).toBeUndefined();
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$user_id=eq.5'),
+    ).toBeUndefined();
+  });
+
+  test('should remove keys by prefix in a cluster', async () => {
+    const entry = createEntry('name');
+    await redisStore.set(postsNamespace, 'public$posts$select=*', entry);
+    await redisStore.set(postsNamespace, 'public$posts$user_id=eq.5', entry);
+    await redisStore.set(commentsNamespace, 'public$comments$select=*', entry);
+
+    await redisStore.removeByPrefix(postsNamespace, 'public$posts');
+
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*'),
+    ).toBeUndefined();
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$user_id=eq.5'),
+    ).toBeUndefined();
+    expect(
+      await redisStore.get(commentsNamespace, 'public$comments$select=*'),
+    ).toBeDefined();
+  });
+
+  test('should remove keys by pattern in a cluster', async () => {
+    const entry = createEntry('name');
+    await redisStore.set(
+      postsNamespace,
+      'public$posts$select=*&user_id=eq.5',
+      entry,
+    );
+    await redisStore.set(
+      postsNamespace,
+      'public$posts$select=*&user_id=eq.10',
+      entry,
+    );
+    await redisStore.set(
+      postsNamespace,
+      'public$posts$select=*&status=eq.active',
+      entry,
+    );
+
+    await redisStore.removeByPattern(
+      postsNamespace,
+      'public$posts$*user_id=eq.5*',
+    );
+
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.5'),
+    ).toBeUndefined();
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*&user_id=eq.10'),
+    ).toBeDefined();
+    expect(
+      await redisStore.get(postsNamespace, 'public$posts$select=*&status=eq.active'),
     ).toBeDefined();
   });
 });

--- a/packages/postgrest-server/tests/swr-cache.test.ts
+++ b/packages/postgrest-server/tests/swr-cache.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 
 const fresh = 1000;
 const stale = 2000;
+const namespace = 'public$posts';
 const key = 'key';
 const value = randomUUID();
 
@@ -30,81 +31,90 @@ beforeEach(() => {
 });
 
 test('should store value in the cache', async () => {
-  await cache.set<string>(key, createCacheValue(value));
-  expect((await cache.get(key))?.data).toEqual(value);
+  await cache.set<string>(namespace, key, createCacheValue(value));
+  expect((await cache.get(namespace, key))?.data).toEqual(value);
 });
 
 test('should return undefined if key does not exist in cache', async () => {
-  expect(await cache.get('doesnotexist')).toEqual(undefined);
+  expect(await cache.get(namespace, 'doesnotexist')).toEqual(undefined);
 });
 
 test('should remove value from cache', async () => {
-  await cache.set(key, createCacheValue(value));
-  await cache.remove(key);
-  expect(await cache.get(key)).toEqual(undefined);
+  await cache.set(namespace, key, createCacheValue(value));
+  await cache.remove(namespace, key);
+  expect(await cache.get(namespace, key)).toEqual(undefined);
 });
 
 test('should remove values by prefix', async () => {
-  await cache.set('prefix$key1', createCacheValue('value1'));
-  await cache.set('prefix$key2', createCacheValue('value2'));
-  await cache.set('other$key3', createCacheValue('value3'));
+  await cache.set(namespace, 'prefix$key1', createCacheValue('value1'));
+  await cache.set(namespace, 'prefix$key2', createCacheValue('value2'));
+  await cache.set(namespace, 'other$key3', createCacheValue('value3'));
 
-  await cache.removeByPrefix('prefix$');
+  await cache.removeByPrefix(namespace, 'prefix$');
 
-  expect(await cache.get('prefix$key1')).toEqual(undefined);
-  expect(await cache.get('prefix$key2')).toEqual(undefined);
-  expect((await cache.get('other$key3'))?.data).toEqual('value3');
+  expect(await cache.get(namespace, 'prefix$key1')).toEqual(undefined);
+  expect(await cache.get(namespace, 'prefix$key2')).toEqual(undefined);
+  expect((await cache.get(namespace, 'other$key3'))?.data).toEqual('value3');
 });
 
 test('should remove values by pattern', async () => {
-  await cache.set('public$posts$user_id=eq.5&select=*', createCacheValue('v1'));
   await cache.set(
+    namespace,
+    'public$posts$user_id=eq.5&select=*',
+    createCacheValue('v1'),
+  );
+  await cache.set(
+    namespace,
     'public$posts$user_id=eq.10&select=*',
     createCacheValue('v2'),
   );
-  await cache.set('public$posts$status=eq.active', createCacheValue('v3'));
-
-  await cache.removeByPattern('public$posts$*user_id=eq.5*');
-
-  expect(await cache.get('public$posts$user_id=eq.5&select=*')).toEqual(
-    undefined,
+  await cache.set(
+    namespace,
+    'public$posts$status=eq.active',
+    createCacheValue('v3'),
   );
+
+  await cache.removeByPattern(namespace, 'public$posts$*user_id=eq.5*');
+
   expect(
-    (await cache.get('public$posts$user_id=eq.10&select=*'))?.data,
+    await cache.get(namespace, 'public$posts$user_id=eq.5&select=*'),
+  ).toEqual(undefined);
+  expect(
+    (await cache.get(namespace, 'public$posts$user_id=eq.10&select=*'))?.data,
   ).toEqual('v2');
-  expect((await cache.get('public$posts$status=eq.active'))?.data).toEqual(
-    'v3',
-  );
+  expect(
+    (await cache.get(namespace, 'public$posts$status=eq.active'))?.data,
+  ).toEqual('v3');
 });
 
 test('evicts outdated data', async () => {
-  await cache.set(key, createCacheValue(value));
+  await cache.set(namespace, key, createCacheValue(value));
   await new Promise((r) => setTimeout(r, 3000));
-  const res = await cache.get(key);
+  const res = await cache.get(namespace, key);
   expect(res).toEqual(undefined);
 });
 
 test('returns stale data', async () => {
-  await cache.set(key, createCacheValue(value));
+  await cache.set(namespace, key, createCacheValue(value));
   await new Promise((r) => setTimeout(r, 1500));
-  const res = await cache.get(key);
+  const res = await cache.get(namespace, key);
   expect(res?.data).toEqual(value);
 });
 
 describe('with fresh data', () => {
   test('does not fetch from origin', async () => {
-    await cache.set(key, createCacheValue(value));
+    await cache.set(namespace, key, createCacheValue(value));
     await new Promise((r) => setTimeout(r, 500));
 
     let fetchedFromOrigin = false;
-    const stale = await cache.swr(key, () => {
+    const stale = await cache.swr(namespace, key, () => {
       fetchedFromOrigin = true;
       return Promise.resolve(createCacheValue('fresh_data'));
     });
     expect(stale?.data).toEqual(value);
 
     await new Promise((r) => setTimeout(r, 500));
-    const res = await cache.get(key);
+    const res = await cache.get(namespace, key);
     expect(res?.data).toEqual(value);
     expect(fetchedFromOrigin).toBe(false);
   });
@@ -112,15 +122,15 @@ describe('with fresh data', () => {
 
 describe('with stale data', () => {
   test('fetches from origin', async () => {
-    await cache.set(key, createCacheValue(value));
+    await cache.set(namespace, key, createCacheValue(value));
     await new Promise((r) => setTimeout(r, 1500));
-    const stale = await cache.swr(key, () =>
+    const stale = await cache.swr(namespace, key, () =>
       Promise.resolve(createCacheValue('fresh_data')),
     );
     expect(stale?.data).toEqual(value);
 
     await new Promise((r) => setTimeout(r, 1500));
-    const res = await cache.get(key);
+    const res = await cache.get(namespace, key);
     expect(res).toEqual(createCacheValue('fresh_data'));
   });
 });
@@ -137,7 +147,7 @@ describe('with fresh=0', () => {
 
     let revalidated = 0;
     for (let i = 0; i < 100; i++) {
-      const res = await cache.swr(key, async () => {
+      const res = await cache.swr(namespace, key, async () => {
         revalidated++;
         return createCacheValue(i.toString());
       });


### PR DESCRIPTION
Add Redis Cluster support to the PostgREST server cache store by introducing namespace-aware store operations and stable Redis hash-tagged keys. Query cache namespaces are derived from the table prefix, so all Redis values and namespace index data for a table colocate in one cluster slot.

**Namespace Indexing**

RedisStore now maintains a per-namespace sorted-set index of logical cache keys. Prefix and pattern invalidation use that index instead of Redis keyspace SCAN, avoiding missed keys in Redis Cluster and bounding invalidation work with batched ZSCAN reads.

**Cluster-Safe Redis Client**

RedisStore accepts both standalone Redis and Redis Cluster clients, uses the same key shape for both, and keeps explicit removals synchronized with the namespace index.

Validated with targeted key, memory, Redis, and SWR tests, plus lint and build.